### PR TITLE
Fix printed version

### DIFF
--- a/src/main/scala/com/codacy/CodacyCoverageReporter.scala
+++ b/src/main/scala/com/codacy/CodacyCoverageReporter.scala
@@ -62,7 +62,7 @@ object CodacyCoverageReporter {
 
   def buildParser = {
     new scopt.OptionParser[Config]("codacy-coverage-reporter") {
-      head("codacy-coverage-reporter", "1.0.0")
+      head("codacy-coverage-reporter", getClass.getPackage.getImplementationVersion)
       opt[Language.Value]('l', "language").required().action { (x, c) =>
         c.copy(language = x)
       }.text("your project language")


### PR DESCRIPTION
Instead of harcoded string (previously "1.0.0" since forever), now getting the from `build.sbt`

From: http://stackoverflow.com/questions/8957025/sbt-including-the-version-number-in-a-program

Closes #8 