### PR TITLE
Include documentation for usage with Travis CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,22 @@ Thanks to the amazing job of [halkeye](https://github.com/halkeye) you can now s
 
 Just follow the [instructions on his repository](https://github.com/halkeye/codacy-maven-plugin/blob/master/README.md#usage).
 
+### Travis CI
+
+If you want to use codacy with Travis CI and report coverage generated from your tests run in Travis, update your .travis.yml to include the following blocks:
+
+```yaml
+before_install:
+  - curl -sL https://github.com/jpm4j/jpm4j.installers/raw/master/dist/biz.aQute.jpm.run.jar >jpm4j.jar
+  - java -jar jpm4j.jar -u init
+  - ~/jpm/bin/jpm install com.codacy:codacy-coverage-reporter:assembly
+
+after_success:
+  - ~/jpm/bin/codacy-coverage-reporter -l Java -r build/reports/jacoco/test/jacocoTestReport.xml
+```
+
+Make sure you have set `CODACY_PROJECT_TOKEN` as an environment variable in your travis job! 
+
 ## Troubleshooting
 
 If you receive a `Failed to upload report: Not Found`error when running the command, then you'll probably have codacy-coverage-reporter 1.0.3 installed. Make sure you install version 1.0.4, that fixes that error.


### PR DESCRIPTION
Hi everyone,

when trying to use the codacy-coverage-reporter in Travis CI strictly following the README in this repo, I failed.

However, I figured out a way to use codacy with Travis and I documented it here. If there is a better place for this kind of documentation, please tell me where I should move it. If not, I propose to merge this into master and help others trying to setup codacy with Travis CI.

Regards,

Tobi