### PR TITLE
Bump dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 
 name := "codacy-coverage-reporter"
 
-version := "1.0.5"
+version := "1.0.14"
 
 scalaVersion := "2.11.6"
 
@@ -23,6 +23,9 @@ libraryDependencies ++= Seq(
   codacyScalaApi,
   coverageParser,
   scopt,
+  log,
+  playLog,
+  raptureJsonPlay,
   scalaTest
 )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,9 +2,14 @@ import sbt._
 
 object Dependencies {
 
-  lazy val codacyScalaApi = "com.codacy" %% "codacy-api-scala" % "1.0.2"
-  lazy val coverageParser = "com.codacy" %% "coverage-parser" % "1.1.4"
+  lazy val codacyScalaApi = "com.codacy" %% "codacy-api-scala" % "2.0.4"
+  lazy val coverageParser = "com.codacy" %% "coverage-parser" % "1.1.9"
   lazy val scopt = "com.github.scopt" %% "scopt" % "3.3.0"
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "2.2.4" % "test"
+  lazy val log = "ch.qos.logback" % "logback-classic" % "1.2.1"
+  lazy val playLog = "com.typesafe.play" % "play-logback_2.11" % "2.5.12"
+  lazy val raptureJsonPlay = "com.propensive" %% "rapture-json-play" % "2.0.0-M7" 
+
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "2.2.4" % "test" 
+
 
 }


### PR DESCRIPTION
> Note: it will fail the build until codacy-api-scala 2.0.4 and coverage-parser 1.1.14 are released to maven central