### PR TITLE
CodacyCoverageReporter: Add support for AWS CodeBuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Codacy automatically detects the CommitUUID from several sources:
 * CIRCLE_SHA1
 * CI_COMMIT_ID
 * WERCKER_GIT_COMMIT
+* CODEBUILD_RESOLVED_SOURCE_VERSION
 
 **Git directory**
 

--- a/src/main/scala/com/codacy/CodacyCoverageReporter.scala
+++ b/src/main/scala/com/codacy/CodacyCoverageReporter.scala
@@ -57,7 +57,8 @@ object CodacyCoverageReporter {
       getNonEmptyEnv("DRONE_COMMIT") orElse
       getNonEmptyEnv("CIRCLE_SHA1") orElse
       getNonEmptyEnv("CI_COMMIT_ID") orElse
-      getNonEmptyEnv("WERCKER_GIT_COMMIT")
+      getNonEmptyEnv("WERCKER_GIT_COMMIT") orElse
+      getNonEmptyEnv("CODEBUILD_RESOLVED_SOURCE_VERSION")
         .filter(_.trim.nonEmpty)
   }
 


### PR DESCRIPTION
AWS CodeBuild doesn't copy out the .git directory (known issue discussed
here: https://forums.aws.amazon.com/thread.jspa?threadID=244197).
However, they do provide us with an environment variable we
can use.  Put this detection in the CodacyCoverageReporter so that we
can auto-resolve this and not have to use the --commitUUID flag.

[ Documentation: Updated the README ]
[ Testing: Build ]