### PR TITLE
Disables debug level logs by default 

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date %-16level %-10.-10logger %message %n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="application" level="INFO"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
When we changed to StrictLogging instead of LazyLogging [in this commit](https://github.com/codacy/codacy-coverage-reporter/commit/45afbcf0e5ba1e9473e02a64fdb738ee0309f97e) the jar started to assume debug level by default (however, the native image is ok). 
With this the info level is set by default on both artifacts.