### PR TITLE
fix: Adds new flags to fix the native image build (fixes #125)

### DIFF
--- a/scripts/publish-native.sh
+++ b/scripts/publish-native.sh
@@ -81,6 +81,8 @@ function build_cmd() {
   FLAGS+=' --enable-url-protocols=http,https,file,jar --enable-all-security-services'
   FLAGS+=' -H:+JNI -H:IncludeResourceBundles=com.sun.org.apache.xerces.internal.impl.msg.XMLMessages'
   FLAGS+=' -H:+ReportExceptionStackTraces'
+  FLAGS+=' --no-fallback --initialize-at-build-time'
+  FLAGS+=' --report-unsupported-elements-at-runtime'
   #  FLAGS+=' -H:+ReportUnsupportedElementsAtRuntime'
 
   if [ "${OS_TARGET}" != "darwin" ]


### PR DESCRIPTION
The native image build got broken after upgrading the graalvm image.
We had to add a new flag to initialize classes and implicitly all of their superclasses during image building (--initialize-at-build-time).
The --no-fallback flag is to avoid falling back to JDK if the build is not successfull and the -report-unsupported-elements-at-runtime flag is to report usage of unsupported methods and fields at run time when they are accessed the first time, instead of as an error during image building.