### PR TITLE
Bump codacy-parser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,15 +26,14 @@ references:
       name: CleanCache
       command: |
         find $HOME/.sbt -name "*.lock" | xargs rm | true
-        find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm | true
-
+        
   save_sbt_cache: &save_sbt_cache
     save_cache:
       key: sbt-cache-{{ .Branch }}-{{ checksum "build.sbt" }}-{{ .Environment.CIRCLE_SHA1 }}
       paths:
-        - "~/.ivy2/cache"
         - "~/.sbt"
         - "~/.m2"
+        - "~/.cache/coursier/v1"
 
 jobs:
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ tmp
 codacy.pylint.conf
 npm-debug.log
 config
-
+.bloop
 .metals/
 .vscode/
 .codacy.json

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 
 object Dependencies {
 
-  val coverageParser = "com.codacy" %% "coverage-parser" % "2.0.14"
+  val coverageParser = "com.codacy" %% "coverage-parser" % "2.1.0"
 
   val caseApp = "com.github.alexarchambault" %% "case-app" % "1.2.0"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.2

--- a/src/test/scala/com/codacy/rules/ConfigurationRulesTest.scala
+++ b/src/test/scala/com/codacy/rules/ConfigurationRulesTest.scala
@@ -33,8 +33,7 @@ class ConfigurationRulesTest extends FlatSpec with Matchers with OptionValues {
     inside(components.validatedConfig) {
       case config: ReportConfig =>
         val result = components.reportRules.coverageWithTokenAndCommit(config)
-
-        result should be(Left("Could not parse report, unrecognized report format (tried: Cobertura, Jacoco)"))
+        result should be(Left("Could not parse report, unrecognized report format (tried: Cobertura, Jacoco, LCOV)"))
     }
   }
 


### PR DESCRIPTION
- This bumps `coverage-parser` to `2.1.0`.
   - Adds support for LCOV https://github.com/codacy/coverage-parser/pull/37
- Updates sbt to 1.3.2
- I'm delaying the update of circle build to orbs to another task.