### PR TITLE
fix: Update instructions on the gradle task

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,11 +221,10 @@ Gradle task by [Mr_ramych](https://github.com/MrRamych). Made up from solution a
 ```gradle
 configurations { codacy }
 repositories {
-    maven { url "https://jitpack.io" }
-    maven { url "http://dl.bintray.com/typesafe/maven-releases" }
+    jcenter()
 }
 dependencies {
-    codacy 'com.github.codacy:codacy-coverage-reporter:-SNAPSHOT'
+    codacy 'com.codacy:codacy-coverage-reporter:latest.release'
 }
 task sendCoverageToCodacy(type: JavaExec, dependsOn: jacocoTestReport) {
     main = "com.codacy.CodacyCoverageReporter"


### PR DESCRIPTION
this fix the Gradle task instructions pointing to a stable release.