### PR TITLE
feature: Add PHPUnit xml format as discoverable format

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This command assumes the coverage reports follow a name convention:
 * Clover &rarr; clover.xml
 * DotCover &rarr; dotcover.xml
 * OpenCover &rarr; opencover.xml
-* PHPUnit XML &rarr; index.xml
+* PHPUnit XML &rarr; coverage-xml/index.xml
 
 Otherwise, you must define the report's location with the flag `-r`.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This command assumes the coverage reports follow a name convention:
 * Clover &rarr; clover.xml
 * DotCover &rarr; dotcover.xml
 * OpenCover &rarr; opencover.xml
+* PHPUnit XML &rarr; index.xml
 
 Otherwise, you must define the report's location with the flag `-r`.
 

--- a/src/main/scala/com/codacy/rules/ReportRules.scala
+++ b/src/main/scala/com/codacy/rules/ReportRules.scala
@@ -44,7 +44,7 @@ class ReportRules(config: Configuration, coverageServices: => CoverageServices) 
             for {
               _ <- validateFileAccess(file)
               report <- CoverageParser.parse(rootProjectDir, file).map(transform(_)(finalConfig))
-              _ <- storeReport(report, file, finalConfig)
+              _ <- storeReport(report, file)
               language <- guessReportLanguage(finalConfig.languageOpt, report)
               success <- sendReport(report, language, finalConfig, commitUUID, file)
             } yield { success }
@@ -57,7 +57,7 @@ class ReportRules(config: Configuration, coverageServices: => CoverageServices) 
     }
   }
 
-  private def validateFileAccess(file: File) = {
+  private[rules] def validateFileAccess(file: File) = {
     file match {
       case file if !file.exists =>
         Left(s"File ${file.getAbsolutePath} does not exist.")
@@ -74,10 +74,9 @@ class ReportRules(config: Configuration, coverageServices: => CoverageServices) 
     * Store the parsed report for troubleshooting purposes
     * @param report coverage report to be stored
     * @param file report file
-    * @param config configuration
     * @return either an error message or nothing
     */
-  private def storeReport(report: CoverageReport, file: File, config: ReportConfig) = {
+  private[rules] def storeReport(report: CoverageReport, file: File) = {
     if (report.fileReports.isEmpty)
       Left(s"The provided coverage report ${file.getAbsolutePath} generated an empty result.")
     else {
@@ -90,7 +89,7 @@ class ReportRules(config: Configuration, coverageServices: => CoverageServices) 
       FileHelper.writeJsonToFile(codacyReportFile, report)
 
       logUploadedFileInfo(codacyReportFile)
-      Right(())
+      Right(codacyReportFilename)
     }
   }
 

--- a/src/main/scala/com/codacy/rules/ReportRules.scala
+++ b/src/main/scala/com/codacy/rules/ReportRules.scala
@@ -57,12 +57,11 @@ class ReportRules(config: Configuration, coverageServices: => CoverageServices) 
               result
           }
 
-        if (reportResults.forall(_.isRight))
-          Right("All coverage data uploaded.")
-        else if (reportResults.exists(_.isRight))
-          Right("Not all files were successfully uploaded.")
-        else
-          Left("No files were uploaded.")
+        reportResults match {
+          case result if result.forall(_.isRight) => Right("All coverage data uploaded.")
+          case result if result.exists(_.isRight) => Right("Not all files were successfully uploaded.")
+          case _ => Left("No files were uploaded.")
+        }
       }
     }
   }

--- a/src/test/scala/com/codacy/rules/ReportRulesSpec.scala
+++ b/src/test/scala/com/codacy/rules/ReportRulesSpec.scala
@@ -127,21 +127,23 @@ class ReportRulesSpec extends WordSpec with Matchers with PrivateMethodTester wi
       result should be('left)
     }
 
-    "successfully report" in {
-      val emptyReport = CoverageReport(0, List(CoverageFileReport("file-name", 0, Map())))
-      val tempFile = File.createTempFile("storeReport", "not-store")
-      val result = components.reportRules.storeReport(emptyReport, tempFile)
+    "report is stored" when {
+      def storeValidReport() = {
+        val emptyReport = CoverageReport(0, List(CoverageFileReport("file-name", 0, Map())))
+        val tempFile = File.createTempFile("storeReport", "not-store")
+        components.reportRules.storeReport(emptyReport, tempFile)
+      }
 
-      result should be('right)
-    }
+      "store is successful" in {
+        val result = storeValidReport()
+        result should be('right)
+      }
 
-    "store report" in {
-      val emptyReport = CoverageReport(0, List(CoverageFileReport("file-name", 0, Map())))
-      val tempFile = File.createTempFile("storeReport", "not-store")
-      val result = components.reportRules.storeReport(emptyReport, tempFile)
-
-      val resultFile = new File(result.right.value)
-      resultFile.exists should be(true)
+      "store report" in {
+        val result = storeValidReport()
+        val resultFile = new File(result.right.value)
+        resultFile.exists should be(true)
+      }
     }
   }
 }

--- a/src/test/scala/com/codacy/rules/ReportRulesSpec.scala
+++ b/src/test/scala/com/codacy/rules/ReportRulesSpec.scala
@@ -87,4 +87,61 @@ class ReportRulesSpec extends WordSpec with Matchers with PrivateMethodTester wi
       reportEither.right.value should be(List(new File("coverage-xml", "index.xml")))
     }
   }
+
+  "validateFileAccess" should {
+    "not validate file" when {
+      "file does not exist" in {
+        val file = new File("not-exist.xml")
+        val result = components.reportRules.validateFileAccess(file)
+
+        result should be('left)
+      }
+
+      "file does not have read access" in {
+        val file = File.createTempFile("validateFileAccess", "read-access")
+        file.createNewFile()
+        file.setReadable(false)
+        file.deleteOnExit()
+
+        val result = components.reportRules.validateFileAccess(file)
+        result should be('left)
+      }
+    }
+
+    "validate file" in {
+      val file = File.createTempFile("validateFileAccess", "valid")
+      file.createNewFile()
+      file.deleteOnExit()
+
+      val result = components.reportRules.validateFileAccess(file)
+      result should be('right)
+    }
+  }
+
+  "storeReport" should {
+    "not store report" in {
+      val emptyReport = CoverageReport(0, Seq.empty[CoverageFileReport])
+      val tempFile = File.createTempFile("storeReport", "not-store")
+      val result = components.reportRules.storeReport(emptyReport, tempFile)
+
+      result should be('left)
+    }
+
+    "successfully report" in {
+      val emptyReport = CoverageReport(0, List(CoverageFileReport("file-name", 0, Map())))
+      val tempFile = File.createTempFile("storeReport", "not-store")
+      val result = components.reportRules.storeReport(emptyReport, tempFile)
+
+      result should be('right)
+    }
+
+    "store report" in {
+      val emptyReport = CoverageReport(0, List(CoverageFileReport("file-name", 0, Map())))
+      val tempFile = File.createTempFile("storeReport", "not-store")
+      val result = components.reportRules.storeReport(emptyReport, tempFile)
+
+      val resultFile = new File(result.right.value)
+      resultFile.exists should be(true)
+    }
+  }
 }

--- a/src/test/scala/com/codacy/rules/ReportRulesSpec.scala
+++ b/src/test/scala/com/codacy/rules/ReportRulesSpec.scala
@@ -78,5 +78,13 @@ class ReportRulesSpec extends WordSpec with Matchers with PrivateMethodTester wi
       reportEither should be('right)
       reportEither.right.value should be(files)
     }
+
+    "only provide phpunit report file inside coverage-xml" in {
+      val fileIterator = Iterator(new File("index.xml"), new File("coverage-xml", "index.xml"))
+      val reportEither = components.reportRules.guessReportFiles(List.empty, fileIterator)
+
+      reportEither should be('right)
+      reportEither.right.value should be(List(new File("coverage-xml", "index.xml")))
+    }
   }
 }


### PR DESCRIPTION
Discover PHP Unit xml if report file not given.
Given thtat PHP Unit xmls are named index.xml, which is a common name, changed tool to succeed if one of the reports is correctly sent to the coverage service