### PR TITLE
feature: Remove jq dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ export CODACY_USERNAME=%Username%
 
 Additional requirements:
 
-- jq
 - curl
 
 ```bash

--- a/get.sh
+++ b/get.sh
@@ -78,7 +78,7 @@ codacy_reporter="$codacy_temp_folder/codacy-coverage-reporter-assembly.jar"
 if [ ! -f "$codacy_reporter" ]
 then
     log "$i" "Download the codacy reporter... ($CODACY_REPORTER_VERSION)"
-    curl -LS -o "$codacy_reporter" "$(curl -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/$CODACY_REPORTER_VERSION | jq -r '.assets | map({name, browser_download_url} | select(.name | endswith(".jar"))) | .[0].browser_download_url')"
+    curl -LS -o "$codacy_reporter" "$(curl -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/$CODACY_REPORTER_VERSION | grep browser_download_url | grep jar | cut -d '"' -f 4)"
 else
     log "$i" "Using codacy reporter from cache"
 fi


### PR DESCRIPTION
You should be able to run the script with installing any additional packages (see #160).
Unless we are supporting other OS, this should be enough for downloading the reporter.