### PR TITLE
feature: Stop publishing to sonatype

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ workflows:
       - pack_and_validate:
           context: CodacyCircleCI
           requires:
-            - codacy/checkout_and_version            
+            - codacy/checkout_and_version
       - codacy/sbt:
           name: populate_cache
           cmd: sbt ";set scalafmtUseIvy in ThisBuild := false;update"
@@ -94,9 +94,9 @@ workflows:
           requires:
             - compile
       - codacy/sbt:
-          name: publish
+          name: package_artifacts
           cmd: |
-            sbt ";clean;retrieveGPGKeys;publishSigned;sonatypeRelease"
+            sbt "assembly"
 
             ./scripts/publish-native.sh -n codacy-coverage-reporter -m com.codacy.CodacyCoverageReporter -t docker $(cat .version)
 
@@ -113,7 +113,7 @@ workflows:
                 - master
       - publish_circleci_artifacts:
           requires:
-            - publish
+            - package_artifacts
       #TODO: Add bintray orb
       - codacy/shell:
           name: publish_bintray
@@ -127,13 +127,13 @@ workflows:
                 - master
           context: CodacyBintray
           requires:
-            - publish
+            - package_artifacts
       - codacy/publish_ghr:
           name: publish_ghr
           path: ~/workdir/artifacts/
           context: CodacyGitHub
           requires:
-            - publish
+            - package_artifacts
       - publish_dev:
           context: CodacyCircleCI
           requires:

--- a/build.sbt
+++ b/build.sbt
@@ -31,20 +31,13 @@ assemblyMergeStrategy in assembly := {
   case m if m.toLowerCase.matches("meta-inf.*\\.sf$") => MergeStrategy.discard
   case _ => MergeStrategy.first
 }
+test in assembly := {}
 crossPaths := false
-artifact in (Compile, assembly) := {
-  val art = (artifact in (Compile, assembly)).value
-  art.withClassifier(Some("assembly"))
-}
-addArtifact(artifact in (Compile, assembly), assembly)
 
 // HACK: Since we are only using the public resolvers we need to remove the private for it to not fail
 resolvers ~= {
   _.filterNot(_.name.toLowerCase.contains("codacy"))
 }
-
-// HACK: This setting is not picked up properly from the plugin
-pgpPassphrase := Option(System.getenv("SONATYPE_GPG_PASSPHRASE")).map(_.toCharArray)
 
 description := "CLI to send coverage reports to Codacy through the API"
 
@@ -54,8 +47,6 @@ scmInfo := Some(
     "scm:git:git@github.com:codacy/codacy-coverage-reporter.git"
   )
 )
-
-publicMvnPublish
 
 fork in Test := true
 cancelable in Global := true


### PR DESCRIPTION
It doesn't make sense to publish the reporter as a library, since it is supposed to be used as a binary.
