### PR TITLE
feature: Add support for GitHub Actions provider

### DIFF
--- a/src/main/scala/com/codacy/rules/commituuid/CommitUUIDProvider.scala
+++ b/src/main/scala/com/codacy/rules/commituuid/CommitUUIDProvider.scala
@@ -116,6 +116,7 @@ object CommitUUIDProvider extends StrictLogging {
       new CodefreshCIProvider,
       new CodeshipCIProvider,
       new DockerProvider,
+      new GitHubActionProvider,
       new GitlabProvider,
       new GreenhouseCIProvider,
       new HerokuCIProvider,

--- a/src/main/scala/com/codacy/rules/commituuid/providers/GitHubActionProvider.scala
+++ b/src/main/scala/com/codacy/rules/commituuid/providers/GitHubActionProvider.scala
@@ -1,0 +1,15 @@
+package com.codacy.rules.commituuid.providers
+
+import com.codacy.rules.commituuid.CommitUUIDProvider
+import com.codacy.model.configuration.CommitUUID
+
+class GitHubActionProvider extends CommitUUIDProvider {
+  val name: String = "GitHub Actions"
+
+  override def validate(a: Map[String, String]): Boolean = {
+    a.get("CI").contains("true") && a.get("GITHUB_ACTIONS").contains("true")
+  }
+
+  override def getUUID(a: Map[String, String]): Either[String, CommitUUID] =
+    withErrorMessage(a.get("GITHUB_SHA"))
+}


### PR DESCRIPTION
Add ability to get commit id from GitHub actions

Based on [this](https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables).