### PR TITLE
fix: Change generated JSON file directory to tmp folder :breaking:

### DIFF
--- a/src/main/scala/com/codacy/rules/ReportRules.scala
+++ b/src/main/scala/com/codacy/rules/ReportRules.scala
@@ -92,16 +92,14 @@ class ReportRules(coverageServices: => CoverageServices) extends LogSupport {
     if (report.fileReports.isEmpty)
       Left(s"The provided coverage report ${file.getAbsolutePath} generated an empty result.")
     else {
-      val codacyReportFilename =
-        s"${file.getAbsoluteFile.getParent}${File.separator}codacy-coverage.json"
-      logger.debug(s"Saving parsed report to $codacyReportFilename")
-      val codacyReportFile = new File(codacyReportFilename)
+      val codacyReportFile = File.createTempFile("codacy-coverage-", ".json")
 
+      logger.debug(s"Saving parsed report to ${codacyReportFile.getAbsolutePath}")
       logger.debug(report.toString)
       FileHelper.writeJsonToFile(codacyReportFile, report)
 
       logUploadedFileInfo(codacyReportFile)
-      Right(codacyReportFilename)
+      Right(codacyReportFile.getAbsolutePath)
     }
   }
 


### PR DESCRIPTION
The file is now generated in a temporary folder with a unique name, instead of the same folder where the report is.
This file is used for troubleshooting purposes.

Fix #217 