### PR TITLE
fix: Send final report in automatic mode :breaking:

### DIFF
--- a/src/main/scala/com/codacy/rules/ReportRules.scala
+++ b/src/main/scala/com/codacy/rules/ReportRules.scala
@@ -38,7 +38,7 @@ class ReportRules(coverageServices: => CoverageServices) extends LogSupport {
       val filesEither = guessReportFiles(config.coverageReports, rootProjectDirIterator)
 
       filesEither.flatMap { files =>
-        def sendFilesReport(partial: Boolean) = {
+        def sendFilesReport(partial: Boolean = config.partial) = {
           val finalConfig = config.copy(partial = partial)
           files
             .map { file =>
@@ -63,7 +63,7 @@ class ReportRules(coverageServices: => CoverageServices) extends LogSupport {
             f <- finalReport(FinalConfig(config.baseConfig))
           } yield f
         } else {
-          sendFilesReport(partial = true)
+          sendFilesReport()
         }
       }
     }

--- a/src/main/scala/com/codacy/rules/ReportRules.scala
+++ b/src/main/scala/com/codacy/rules/ReportRules.scala
@@ -31,6 +31,30 @@ class ReportRules(coverageServices: => CoverageServices) extends LogSupport {
     .asScala
     .map(_.toFile)
 
+  private def sendFilesReportForCommit(
+      files: List[File],
+      config: ReportConfig,
+      partial: Boolean,
+      commitUUID: String
+  ): Either[String, String] = {
+    val finalConfig = config.copy(partial = partial)
+    files
+      .map { file =>
+        logger.info(s"Parsing coverage data from: ${file.getAbsolutePath} ...")
+        for {
+          _ <- validateFileAccess(file)
+          report <- CoverageParser.parse(rootProjectDir, file).map(transform(_)(finalConfig))
+          _ <- storeReport(report, file)
+          language <- guessReportLanguage(finalConfig.languageOpt, report)
+          success <- sendReport(report, language, finalConfig, commitUUID, file)
+        } yield { success }
+      }
+      .collectFirst {
+        case Left(l) => Left(l)
+      }
+      .getOrElse(Right("All coverage data uploaded."))
+  }
+
   def codacyCoverage(config: ReportConfig): Either[String, String] = {
     withCommitUUID(config.baseConfig) { commitUUID =>
       logAuthenticationToken(config)
@@ -38,32 +62,14 @@ class ReportRules(coverageServices: => CoverageServices) extends LogSupport {
       val filesEither = guessReportFiles(config.coverageReports, rootProjectDirIterator)
 
       filesEither.flatMap { files =>
-        def sendFilesReport(partial: Boolean = config.partial) = {
-          val finalConfig = config.copy(partial = partial)
-          files
-            .map { file =>
-              logger.info(s"Parsing coverage data from: ${file.getAbsolutePath} ...")
-              for {
-                _ <- validateFileAccess(file)
-                report <- CoverageParser.parse(rootProjectDir, file).map(transform(_)(finalConfig))
-                _ <- storeReport(report, file)
-                language <- guessReportLanguage(finalConfig.languageOpt, report)
-                success <- sendReport(report, language, finalConfig, commitUUID, file)
-              } yield { success }
-            }
-            .collectFirst {
-              case Left(l) => Left(l)
-            }
-            .getOrElse(Right("All coverage data uploaded."))
-        }
         if (files.length > 1 && !config.partial) {
           logger.info("More than one file. Considering a partial report")
           for {
-            _ <- sendFilesReport(partial = true)
+            _ <- sendFilesReportForCommit(files, config, partial = true, commitUUID)
             f <- finalReport(FinalConfig(config.baseConfig))
           } yield f
         } else {
-          sendFilesReport()
+          sendFilesReportForCommit(files, config, partial = config.partial, commitUUID)
         }
       }
     }


### PR DESCRIPTION
Send final report when guessing multiple files and the --partial
flag is not specified.
In this situation the previous behaviour was to send some partial
reports but without a final at the end. This way users need to
send a manual final right after.
With this change the final is sent automatically.