### PR TITLE
Add detail on downloading binaries manually

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -118,6 +118,10 @@ task sendCoverageToCodacy(type: JavaExec, dependsOn: jacocoTestReport) {
 
 ## Manually downloading the native binary
 
+If you prefer, you can manually download and run the native `codacy-coverage-reporter` binary, either for the latest version or a specific one.
+
+You can use the scripts below to automatically check for the latest version of the binaries, download the binaries from either Bintray or GitHub, and run them.
+
 ### Linux amd64
 
 Download the latest binary and use it to post the coverage to Codacy


### PR DESCRIPTION
Some customers feel more comfortable manually downloading the `codacy-coverage-reporter` binary files.

This was already described in the documentation, but it can be made more apparent why a customer would want to do this and how the scripts work so customers can adapt them if they wish.

More information on [this Slack thread](https://codacy.slack.com/archives/CL70DTJF8/p1593504069046700).