### PR TITLE
fix: Update link to docs on sending partial reports

### DIFF
--- a/src/main/scala/com/codacy/rules/ReportRules.scala
+++ b/src/main/scala/com/codacy/rules/ReportRules.scala
@@ -75,7 +75,7 @@ class ReportRules(coverageServices: => CoverageServices) extends LogSupport {
       if (config.partial) {
         logger.info(
           """To complete the reporting process, call coverage-reporter with the final flag.
-          | Check https://github.com/codacy/codacy-coverage-reporter#multiple-coverage-reports-for-the-same-language
+          | Check https://github.com/codacy/codacy-coverage-reporter/blob/master/docs/advanced/multiple-reports.md
           | for more information.""".stripMargin
         )
       }


### PR DESCRIPTION
As a result of https://github.com/codacy/codacy-coverage-reporter/pull/235, the page containing information on sending partial reports changed to a new location.