### PR TITLE
Fix skip_option

### DIFF
--- a/orbs/commands/send_report.yml
+++ b/orbs/commands/send_report.yml
@@ -46,4 +46,4 @@ steps:
         fi
 
         bash <(curl -Ls https://coverage.codacy.com/get.sh) report $params --partial $skip_option &&\
-        bash <(curl -Ls https://coverage.codacy.com/get.sh) $skip_option final
+        bash <(curl -Ls https://coverage.codacy.com/get.sh) final $skip_option


### PR DESCRIPTION
I think the position of `$skip_option` from commit 7542ac is incorrect. This orb is not runnable currently on CircleCI.

Error message from CircleCI:

```
 --> Download the codacy reporter codacy-coverage-reporter-linux... (latest)
######################################################################## 100.0%
######################################################################## 100.0%
2020-08-18 20:18:48.834Z  info [CodacyCoverageReporter] Skip reporting coverage  - (CodacyCoverageReporter.scala:16)

 --> Succeeded!
     ______          __
    / ____/___  ____/ /___ ________  __
   / /   / __ \/ __  / __ `/ ___/ / / /
  / /___/ /_/ / /_/ / /_/ / /__/ /_/ /
  \____/\____/\__,_/\__,_/\___/\__, /
                              /____/

  Codacy Coverage Reporter

 --> Using codacy reporter codacy-coverage-reporter-linux from cache
Unrecognized argument: --skip

 --> Failed!

Exited with code exit status 1
CircleCI received exit code 1
```