### PR TITLE
style: Improve error message when there is no API token defined

### DIFF
--- a/src/main/scala/com/codacy/rules/ConfigurationRules.scala
+++ b/src/main/scala/com/codacy/rules/ConfigurationRules.scala
@@ -88,7 +88,7 @@ class ConfigurationRules(cmdConfig: CommandConfiguration, envVars: Map[String, S
 
   private def validateAuthConfig(baseCommandConfig: BaseCommandConfig): Either[String, AuthenticationConfig] = {
     val errorMessage =
-      "Either a project token or an api token must be provided or available in an environment variable"
+      "Either a project or account API token must be provided or available in an environment variable"
 
     val projectToken = getValueOrEnvironmentVar(baseCommandConfig.projectToken, "CODACY_PROJECT_TOKEN")
     val apiToken = getValueOrEnvironmentVar(baseCommandConfig.apiToken, "CODACY_API_TOKEN")

--- a/src/test/scala/com/codacy/rules/ConfigurationRulesSpec.scala
+++ b/src/test/scala/com/codacy/rules/ConfigurationRulesSpec.scala
@@ -77,7 +77,7 @@ class ConfigurationRulesSpec extends WordSpec with Matchers with OptionValues wi
         val baseConfig =
           BaseCommandConfig(None, None, Some("username"), Some("projectName"), Some(apiBaseUrl), Some("CommitUUID"))
         val result = assertFailure(baseConfig)
-        result.left.value should include("project token or an api token")
+        result.left.value should include("project or account API token")
       }
 
       "project token is empty" in {


### PR DESCRIPTION
Makes it more explicit that:
- A "project token" is a project API token
- An "api token" is an account API token