### PR TITLE
feature: Use a specific parser for coverage and log the used one

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ scalacOptions := Seq(
 
 // Runtime dependencies
 libraryDependencies ++= Seq(
-  "com.codacy" %% "coverage-parser" % "2.5.6",
+  "com.codacy" %% "coverage-parser" % "4.3.1",
   "com.github.alexarchambault" %% "case-app" % "1.2.0",
   "org.wvlet.airframe" %% "airframe-log" % "20.5.1",
   "com.lihaoyi" %% "ujson" % "1.1.0"

--- a/src/it/scala/com/codacy/CodacyCoverageReporterSpec.scala
+++ b/src/it/scala/com/codacy/CodacyCoverageReporterSpec.scala
@@ -30,7 +30,8 @@ class CodacyCoverageReporterSpec extends WordSpec with Matchers with EitherValue
       baseConfig = baseConfig,
       language = None,
       coverageReports = Some(List(new File("src/test/resources/dotcover-example.xml"))),
-      prefix = None
+      prefix = None,
+      forceCoverageParser = None
     )
 
     val configRules = new ConfigurationRules(commandConfig, Map.empty)

--- a/src/main/scala/com/codacy/configuration/parser/ConfigurationParser.scala
+++ b/src/main/scala/com/codacy/configuration/parser/ConfigurationParser.scala
@@ -5,6 +5,8 @@ import java.io.File
 import caseapp._
 import caseapp.core.ArgParser
 import com.codacy.configuration.parser.ConfigArgumentParsers._
+import com.codacy.parsers.CoverageParser
+import com.codacy.parsers.implementation._
 // Intellij keeps removing this import, I'll leave it here for future reference
 // import com.codacy.configuration.parser.ConfigArgumentParsers._
 
@@ -61,7 +63,10 @@ case class Report(
     @ValueDescription("if the report is partial")
     partial: Int @@ Counter = Tag.of(0),
     @ValueDescription("the project path prefix")
-    prefix: Option[String]
+    prefix: Option[String],
+    @ValueDescription("your coverage parser")
+    @HelpMessage(s"Available parsers are: ${ConfigArgumentParsers.parsersMap.keys.mkString(",")}")
+    forceCoverageParser: Option[CoverageParser]
 ) extends CommandConfiguration {
   val partialValue: Boolean = partial.## > 0
   val forceLanguageValue: Boolean = forceLanguage.## > 0
@@ -92,4 +97,25 @@ case class BaseCommandConfig(
 object ConfigArgumentParsers {
 
   implicit val fileParser: ArgParser[File] = ArgParser.instance("file")(a => Right(new File(a)))
+
+  val parsersMap = Map(
+    "cobertura" -> CoberturaParser,
+    "jacoco" -> JacocoParser,
+    "clover" -> CloverParser,
+    "opencover" -> OpenCoverParser,
+    "dotcover" -> DotcoverParser,
+    "phpunit" -> PhpUnitXmlParser,
+    "lcov" -> LCOVParser
+  )
+
+  implicit val coverageParser: ArgParser[CoverageParser] = ArgParser.instance("parser") { v =>
+    val value = v.trim.toLowerCase
+    parsersMap.get(value) match {
+      case Some(parser) => Right(parser)
+      case _ =>
+        Left(
+          s"${value} is an unsupported/unrecognized coverage parser. (Available patterns are: ${parsersMap.keys.mkString(",")})"
+        )
+    }
+  }
 }

--- a/src/main/scala/com/codacy/model/configuration/Configuration.scala
+++ b/src/main/scala/com/codacy/model/configuration/Configuration.scala
@@ -2,6 +2,7 @@ package com.codacy.model.configuration
 
 import java.io.File
 
+import com.codacy.parsers.CoverageParser
 import com.codacy.plugins.api.languages.{Language, Languages}
 
 sealed trait Configuration {
@@ -14,7 +15,8 @@ case class ReportConfig(
     forceLanguage: Boolean,
     coverageReports: List[File],
     partial: Boolean,
-    prefix: String
+    prefix: String,
+    forceCoverageParser: Option[CoverageParser]
 ) extends Configuration {
 
   lazy val language: Option[Language] = languageOpt.flatMap(Languages.fromName)

--- a/src/main/scala/com/codacy/rules/ConfigurationRules.scala
+++ b/src/main/scala/com/codacy/rules/ConfigurationRules.scala
@@ -63,7 +63,8 @@ class ConfigurationRules(cmdConfig: CommandConfiguration, envVars: Map[String, S
         reportConfig.forceLanguageValue,
         validReportFiles,
         reportConfig.partialValue,
-        reportConfig.prefix.getOrElse("")
+        reportConfig.prefix.getOrElse(""),
+        reportConfig.forceCoverageParser
       )
       validatedConfig <- validate(reportConf)
     } yield validatedConfig

--- a/src/main/scala/com/codacy/rules/ReportRules.scala
+++ b/src/main/scala/com/codacy/rules/ReportRules.scala
@@ -43,7 +43,11 @@ class ReportRules(coverageServices: => CoverageServices) extends LogSupport {
         logger.info(s"Parsing coverage data from: ${file.getAbsolutePath} ...")
         for {
           _ <- validateFileAccess(file)
-          report <- CoverageParser.parse(rootProjectDir, file).map(transform(_)(finalConfig))
+          report <- CoverageParser.parse(rootProjectDir, file, forceParser = config.forceCoverageParser).map {
+            coverageResult =>
+              logger.info(s"Coverage parser used is ${coverageResult.parser}")
+              transform(coverageResult.report)(finalConfig)
+          }
           _ <- storeReport(report, file)
           language <- guessReportLanguage(finalConfig.languageOpt, report)
           success <- sendReport(report, language, finalConfig, commitUUID, file)

--- a/src/test/scala/com/codacy/rules/ConfigurationRulesSpec.scala
+++ b/src/test/scala/com/codacy/rules/ConfigurationRulesSpec.scala
@@ -16,7 +16,9 @@ class ConfigurationRulesSpec extends WordSpec with Matchers with OptionValues wi
   val apiBaseUrl = "https://example.com"
 
   val baseConf = BaseCommandConfig(Some(projToken), None, None, None, Some(apiBaseUrl), None)
-  val conf = Report(baseConf, Some("Scala"), coverageReports = Some(coverageFiles), prefix = None)
+
+  val conf =
+    Report(baseConf, Some("Scala"), coverageReports = Some(coverageFiles), prefix = None, forceCoverageParser = None)
 
   val configRules = new ConfigurationRules(conf, Map.empty)
   val validatedConfig = configRules.validatedConfig.right.value

--- a/src/test/scala/com/codacy/rules/ReportRulesSpec.scala
+++ b/src/test/scala/com/codacy/rules/ReportRulesSpec.scala
@@ -20,7 +20,9 @@ class ReportRulesSpec extends WordSpec with Matchers with PrivateMethodTester wi
   val commitUUID = CommitUUID("commitUUID")
 
   val baseConf = BaseCommandConfig(Some(projToken), None, None, None, Some(apiBaseUrl), None)
-  val conf = Report(baseConf, Some("Scala"), coverageReports = Some(coverageFiles), prefix = None)
+
+  val conf =
+    Report(baseConf, Some("Scala"), coverageReports = Some(coverageFiles), prefix = None, forceCoverageParser = None)
 
   val coverageReport = CoverageReport(100, Seq(CoverageFileReport("file.scala", 100, Map(10 -> 1))))
   val noLanguageReport = CoverageReport(0, Seq.empty[CoverageFileReport])
@@ -43,7 +45,8 @@ class ReportRulesSpec extends WordSpec with Matchers with PrivateMethodTester wi
           forceLanguage = false,
           coverageReports = coverageReports.map(new File(_)),
           partial = false,
-          prefix = ""
+          prefix = "",
+          forceCoverageParser = None
         )
       val result = reportRules.codacyCoverage(reportConfig)
 


### PR DESCRIPTION
This is the final step to give the users the possibility of choosing the Coverage Parser they want to use.
We are as well adding a log to make it easier to debug parser's issues in the future.

I will update the documentation as soon as #244 is merged.
@pauloribeiro-codacy I encourage you to go ahead, merge and eventually re-iterate!