### PR TITLE
doc: Make improvements to the codacy-coverage-reporter documentation

### DIFF
--- a/docs/adding-coverage-to-your-repository.md
+++ b/docs/adding-coverage-to-your-repository.md
@@ -4,7 +4,7 @@ Before setting up Codacy to display code coverage metrics for your repository yo
 
 Codacy supports the following coverage report formats:
 
-| Report formats                | Report file names            |
+| Report format                 | Report file name             |
 | ----------------------------- | ---------------------------- |
 | Clover                        | clover.xml                   |
 | Cobertura                     | cobertura.xml                |
@@ -19,7 +19,7 @@ Codacy supports the following coverage report formats:
 
 After having coverage reports set up for your repository, you must use Codacy Coverage Reporter to convert the reports to smaller JSON files and upload these files to Codacy. The recommended way to do this is using a CI/CD platform that automatically runs tests, generates coverage, and uses Codacy Coverage Reporter to upload the coverage report information for every commit.
 
-1.  You must set up an API token to allow Codacy Coverage Reporter to authenticate on Codacy.
+1.  Set up an API token to allow Codacy Coverage Reporter to authenticate on Codacy.
     {: id="authenticate"}
 
     -   **If you're setting up coverage for one repository**, obtain the [project API Token](/repositories-configure/integrations/project-api/) from the page **Integrations** in your Codacy repository settings.

--- a/docs/adding-coverage-to-your-repository.md
+++ b/docs/adding-coverage-to-your-repository.md
@@ -17,7 +17,7 @@ Codacy supports the following coverage report formats:
 !!! note
     If you are generating a report format that Codacy does not yet support, see [submitting coverage from unsupported report formats](troubleshooting-common-issues.md#unsupported-report-formats).
 
-After having coverage reports set up for your repository, you must use Codacy Coverage Reporter to convert the reports to smaller JSON files and upload these files to Codacy:
+After having coverage reports set up for your repository, you must use Codacy Coverage Reporter to convert the reports to smaller JSON files and upload these files to Codacy. The recommended way to do this is using a CI/CD platform that automatically runs tests, generates coverage, and uses Codacy Coverage Reporter to upload the coverage report information for every commit.
 
 1.  You must set up an API token to allow Codacy Coverage Reporter to authenticate on Codacy.
 

--- a/docs/adding-coverage-to-your-repository.md
+++ b/docs/adding-coverage-to-your-repository.md
@@ -20,6 +20,7 @@ Codacy supports the following coverage report formats:
 After having coverage reports set up for your repository, you must use Codacy Coverage Reporter to convert the reports to smaller JSON files and upload these files to Codacy. The recommended way to do this is using a CI/CD platform that automatically runs tests, generates coverage, and uses Codacy Coverage Reporter to upload the coverage report information for every commit.
 
 1.  You must set up an API token to allow Codacy Coverage Reporter to authenticate on Codacy.
+    {: id="authenticate"}
 
     -   **If you're setting up coverage for one repository**, obtain the [project API Token](/repositories-configure/integrations/project-api/) from the page **Integrations** in your Codacy repository settings.
 

--- a/docs/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/alternative-ways-of-running-coverage-reporter.md
@@ -49,7 +49,7 @@ after_success:
   - java -jar codacy-coverage-reporter-assembly.jar report -l Java -r build/reports/jacoco/test/jacocoTestReport.xml
 ```
 
-Make sure that you also [set your project or account API Token](adding-coverage-to-your-repository.md#2-uploading-coverage-reports-to-codacy) as an environment variable in your Travis CI job.
+Make sure that you also [set your project or account API Token](adding-coverage-to-your-repository.md#authenticate) as an environment variable in your Travis CI job.
 
 ### Gradle task
 


### PR DESCRIPTION
This pull request is for working on subsequent improvements to the codacy-coverage-reporter documentation identified in the pull request #244:

- Update section on Travis CI (feedback from @mrfyda "Looks like this section could be updated"). https://github.com/codacy/codacy-coverage-reporter/pull/244#discussion_r482853597
- Add list of repositories with examples of how to generate coverage (feedback from @mrfyda "Ideally, for each language we would have an example of what it takes to set up coverage and report it to Codacy. See here an example: https://github.com/codecov/example-scala"). https://github.com/codacy/codacy-coverage-reporter/pull/244#discussion_r481299879
- Figure out a better solution to list the aliases of the currently supported languages. https://github.com/codacy/codacy-coverage-reporter/pull/244#discussion_r480306611