### PR TITLE
doc: Direct users to instructions on how to upload coverage results

### DIFF
--- a/docs/generating-coverage-reports.md
+++ b/docs/generating-coverage-reports.md
@@ -28,8 +28,4 @@ slather coverage -x --output-directory <report-output-dir> --scheme <project-nam
 
 This will generate a file `cobertura.xml` inside the folder `<report-output-dir>`.
 
-After this, run Codacy Coverage Reporter:
-
-```bash
-bash <(curl -Ls https://coverage.codacy.com/get.sh)
-```
+After this, run Codacy Coverage Reporter to [upload the coverage results to Codacy](adding-coverage-to-your-repository.md).


### PR DESCRIPTION
The command provided was incomplete because it missed the `report` instruction. It is better to direct users to the main instructions on how to run codacy-coverage-reporter instead.