### PR TITLE
doc: Remove instructions on how to authenticate using account API Token

### DIFF
--- a/docs/adding-coverage-to-your-repository.md
+++ b/docs/adding-coverage-to-your-repository.md
@@ -21,23 +21,11 @@ After having coverage reports set up for your repository, you must use Codacy Co
 
 1.  You must set up an API token to allow Codacy Coverage Reporter to authenticate on Codacy.
 
-    -   **If you're setting up coverage for one repository**, obtain the [project API Token](/repositories-configure/integrations/project-api/) from the page **Integrations** in your Codacy repository settings.
+    Obtain the [project API Token](/repositories-configure/integrations/project-api/) from the page **Integrations** in your Codacy repository settings. Then, set the following environment variable to specify your project API Token:
 
-        Then, set the following environment variable to specify your project API Token:
-
-        ```bash
-        export CODACY_PROJECT_TOKEN=<your project API Token>
-        ```
-
-    -   **If you're setting up and automating coverage for multiple repositories**, obtain an [account API Token](https://docs.codacy.com/related-tools/api-tokens/) from the page **Access management** in your Codacy account settings.
-
-        Then, set the following environment variables to specify the account API Token, the username associated with the account API token, and the repository for which you're uploading the coverage information:
-
-        ```bash
-        export CODACY_API_TOKEN=<your account API Token>
-        export CODACY_USERNAME=<your account username>
-        export CODACY_PROJECT_NAME=<name of your repository>
-        ```
+    ```bash
+    export CODACY_PROJECT_TOKEN=<your project API Token>
+    ```
 
     !!! warning
         **Never write API Tokens on your configuration files** and keep your API Tokens well protected, as they grant owner permissions to your projects.

--- a/docs/adding-coverage-to-your-repository.md
+++ b/docs/adding-coverage-to-your-repository.md
@@ -20,6 +20,7 @@ Codacy supports the following coverage report formats:
 After having coverage reports set up for your repository, you must use Codacy Coverage Reporter to convert the reports to smaller JSON files and upload these files to Codacy:
 
 1.  You must set up an API token to allow Codacy Coverage Reporter to authenticate on Codacy.
+    {: id="authenticate"}
 
     Obtain the [project API Token](/repositories-configure/integrations/project-api/) from the page **Integrations** in your Codacy repository settings. Then, set the following environment variable to specify your project API Token:
 

--- a/docs/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/alternative-ways-of-running-coverage-reporter.md
@@ -49,7 +49,7 @@ after_success:
   - java -jar codacy-coverage-reporter-assembly.jar report -l Java -r build/reports/jacoco/test/jacocoTestReport.xml
 ```
 
-Make sure that you also [set your project or account API Token](adding-coverage-to-your-repository.md#2-uploading-coverage-reports-to-codacy) as an environment variable in your Travis CI job.
+Make sure that you also [set your project API Token](adding-coverage-to-your-repository.md#authenticate) as an environment variable in your Travis CI job.
 
 ### Gradle task
 

--- a/docs/troubleshooting-common-issues.md
+++ b/docs/troubleshooting-common-issues.md
@@ -17,7 +17,7 @@ See the [list of languages](https://github.com/codacy/codacy-plugins-api/blob/ma
 
 If you are generating a report format that Codacy does not yet support, try using community projects such as [t-yuki/gocover-cobertura](https://github.com/t-yuki/gocover-cobertura) and [danielpalme/ReportGenerator](https://github.com/danielpalme/ReportGenerator), or alternatively contribute to our [codacy/coverage-parser](https://github.com/codacy/coverage-parser) project.
 
-As a workaround, you can also send the coverage data directly by calling the Codacy API endpoint [saveCoverage](https://api.codacy.com/swagger#savecoverage) (when using a project API Token) or [saveCoverageWithProjectName](https://api.codacy.com/swagger#savecoveragewithprojectname) (when using an account API Token).
+As a workaround, you can also send the coverage data directly by calling the Codacy API endpoint [saveCoverage](https://api.codacy.com/swagger#savecoverage).
 
 The following is an example of the JSON payload:
 

--- a/src/main/scala/com/codacy/configuration/parser/ConfigurationParser.scala
+++ b/src/main/scala/com/codacy/configuration/parser/ConfigurationParser.scala
@@ -75,11 +75,11 @@ case class Report(
 case class BaseCommandConfig(
     @Name("t") @ValueDescription("your project API token")
     projectToken: Option[String],
-    @Name("a") @ValueDescription("your api token")
+    @Name("a") @ValueDescription("your api token") @Hidden
     apiToken: Option[String],
-    @Name("u") @ValueDescription("your username")
+    @Name("u") @ValueDescription("your username") @Hidden
     username: Option[String],
-    @Name("p") @ValueDescription("project name")
+    @Name("p") @ValueDescription("project name") @Hidden
     projectName: Option[String],
     @ValueDescription("the base URL for the Codacy API")
     codacyApiBaseUrl: Option[String],

--- a/src/main/scala/com/codacy/rules/ConfigurationRules.scala
+++ b/src/main/scala/com/codacy/rules/ConfigurationRules.scala
@@ -89,7 +89,7 @@ class ConfigurationRules(cmdConfig: CommandConfiguration, envVars: Map[String, S
 
   private def validateAuthConfig(baseCommandConfig: BaseCommandConfig): Either[String, AuthenticationConfig] = {
     val errorMessage =
-      "Either a project or account API token must be provided or available in an environment variable"
+      "A project API token must be provided or available in an environment variable"
 
     val projectToken = getValueOrEnvironmentVar(baseCommandConfig.projectToken, "CODACY_PROJECT_TOKEN")
     val apiToken = getValueOrEnvironmentVar(baseCommandConfig.apiToken, "CODACY_API_TOKEN")

--- a/src/main/scala/com/codacy/rules/ReportRules.scala
+++ b/src/main/scala/com/codacy/rules/ReportRules.scala
@@ -257,7 +257,7 @@ class ReportRules(coverageServices: => CoverageServices) extends LogSupport {
     */
   private[rules] def handleFailedResponse(response: FailedResponse): String = {
     if (response.message.contains("not found")) {
-      "Request URL not found. Check if the API Token you are using and the API base URL are valid."
+      "Request URL not found. Check if the project API Token you are using and the API base URL are valid."
     } else {
       response.message
     }

--- a/src/test/scala/com/codacy/rules/ConfigurationRulesSpec.scala
+++ b/src/test/scala/com/codacy/rules/ConfigurationRulesSpec.scala
@@ -79,7 +79,7 @@ class ConfigurationRulesSpec extends WordSpec with Matchers with OptionValues wi
         val baseConfig =
           BaseCommandConfig(None, None, Some("username"), Some("projectName"), Some(apiBaseUrl), Some("CommitUUID"))
         val result = assertFailure(baseConfig)
-        result.left.value should include("project or account API token")
+        result.left.value should include("project API token")
       }
 
       "project token is empty" in {


### PR DESCRIPTION
Using the account API Token only works for repositories belonging to legacy organizations and not for synced organizations.

We may add new instructions in the future if we figure out a different solution to submit coverage for multiple repositories without having to use individual project API Tokens for each repository.

See https://codacy.atlassian.net/browse/CY-2862 for more details.