### PR TITLE
fix: Update link to GitHub user profile

### DIFF
--- a/docs/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/alternative-ways-of-running-coverage-reporter.md
@@ -87,7 +87,7 @@ task (codacyLocs) << {
 }
 ```
 
-The following Gradle task by [MrRamych](https://github.com/MrRamych) was based on the solution above.
+The following Gradle task by [Ramil Khamitov](https://github.com/Ram-002) was based on the solution above.
 
 ```gradle
 configurations { codacy }


### PR DESCRIPTION
Apparently, the user must have changed his GitHub username and the previous link no longer works.

I'm fixing this because I enabled an automatic link checker on codacy/docs to find broken links on the documentation: https://github.com/codacy/docs/issues/219