### PR TITLE
fix: Rely on bash built-in instead of coreutils implementation

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -87,9 +87,9 @@ download() {
     local url="$1"
     local output="${2:--}"
 
-    if [ -x "$(which curl)" ]; then
+    if command -v curl > /dev/null 2>&1; then
         curl -# -LS "$url" -o "$output"
-    elif [ -x "$(which wget)" ] ; then
+    elif command -v wget > /dev/null 2>&1; then
         wget "$url" -O "$output"
     else
         fatal "Could not find curl or wget, please install one."


### PR DESCRIPTION
`command` built-in is prefered to `which` command for 2 reasons:
  - `which` is not implemented by POSIX and `command` is POSIX-compliant;
  - It's always preferable to use a bash built-in command if it does what
    you want. Bash does subprocess forking to execute commands inside a
    subshell to maintain the current shell environment and that's expensive.

In this case, performance is obviously not an issue, but I think portability
is very important for this situation.

Reference: http://www.skybert.net/bash/making-your-bash-programs-run-faster/
Reference: https://unix.stackexchange.com/questions/85249/why-not-use-which-what-to-use-then

Signed-off-by: Luís Ferreira <contact@lsferreira.net>