### PR TITLE
Download command in script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ workflows:
           cmd: |
             sbt coverage test
             sbt coverageAggregate
-            bash <(curl -Ls https://coverage.codacy.com/get.sh) report --skip
+            ./get.sh report --skip
           requires:
             - scalafmt_and_compile
       - codacy/sbt:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,12 +24,12 @@ commands:
       - run:
           name: test coverage reporting
           command: |
+            set +e
             export CODACY_PROJECT_TOKEN='TEST_CODACY_PROJECT_TOKEN'
             export TEST_CODACY_REPORT_PATH='integration-tests/test_dotcover.xml'
-            set +e
             export CODACY_REPORTER_TMP_FOLDER=".codacy-coverage"
-            mkdir -p $CODACY_REPORTER_TMP_FOLDER/$CODACY_REPORTER_VERSION
             export CODACY_REPORTER_VERSION=$(cat .version)
+            mkdir -p $CODACY_REPORTER_TMP_FOLDER/$CODACY_REPORTER_VERSION
             cp "$HOME/workdir/artifacts/codacy-coverage-reporter-linux-$CODACY_REPORTER_VERSION" "$CODACY_REPORTER_TMP_FOLDER/$CODACY_REPORTER_VERSION/codacy-coverage-reporter"
             # the following line ensure that we are using the cached binary
             << parameters.executor >> get.sh report --commit-uuid 'e9bef8a69a439bd601c37c0557277572425203a7' -r $TEST_CODACY_REPORT_PATH --codacy-api-base-url http://localhost:1080

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ commands:
             export TEST_CODACY_REPORT_PATH='integration-tests/test_dotcover.xml'
             set +e
             export CODACY_REPORTER_TMP_FOLDER=".codacy-coverage"
-            mkdir -p $CODACY_REPORTER_TMP_FOLDER
+            mkdir -p $CODACY_REPORTER_TMP_FOLDER/$CODACY_REPORTER_VERSION
             export CODACY_REPORTER_VERSION=$(cat .version)
             cp "$HOME/workdir/artifacts/codacy-coverage-reporter-linux-$CODACY_REPORTER_VERSION" "$CODACY_REPORTER_TMP_FOLDER/$CODACY_REPORTER_VERSION/codacy-coverage-reporter"
             # the following line ensure that we are using the cached binary
@@ -165,8 +165,9 @@ jobs:
           command: |
             brew install mockserver coreutils
             export CODACY_REPORTER_TMP_FOLDER=".codacy-coverage"
-            mkdir -p $CODACY_REPORTER_TMP_FOLDER
-            cp $HOME/workdir/artifacts/codacy-coverage-reporter-darwin-$(cat $HOME/workdir/.version) $CODACY_REPORTER_TMP_FOLDER/codacy-coverage-reporter
+            version=$(cat .version)
+            mkdir -p $CODACY_REPORTER_TMP_FOLDER/$version
+            cp $HOME/workdir/artifacts/codacy-coverage-reporter-darwin-$version $CODACY_REPORTER_TMP_FOLDER/$version/codacy-coverage-reporter
       - run:
           name: test on osx
           command: |
@@ -178,7 +179,7 @@ jobs:
             echo "Run the test"
             set +e
             # the following line ensure that we are using the cached binary
-            export CODACY_REPORTER_VERSION=inexistent
+            export CODACY_REPORTER_VERSION=$(cat .version)
             export CODACY_PROJECT_TOKEN='TEST_CODACY_PROJECT_TOKEN'
             export TEST_CODACY_REPORT_PATH='integration-tests/test_dotcover.xml'
             export CODACY_REPORTER_TMP_FOLDER=".codacy-coverage"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,6 @@ commands:
             export CODACY_REPORTER_VERSION=$(cat .version)
             mkdir -p $CODACY_REPORTER_TMP_FOLDER/$CODACY_REPORTER_VERSION
             cp "$HOME/workdir/artifacts/codacy-coverage-reporter-linux-$CODACY_REPORTER_VERSION" "$CODACY_REPORTER_TMP_FOLDER/$CODACY_REPORTER_VERSION/codacy-coverage-reporter"
-            # the following line ensure that we are using the cached binary
             << parameters.executor >> get.sh report --commit-uuid 'e9bef8a69a439bd601c37c0557277572425203a7' -r $TEST_CODACY_REPORT_PATH --codacy-api-base-url http://localhost:1080
             export ERROR_CODE=$?
             if [ $ERROR_CODE -ne << parameters.error_code >> ]; then echo "expected an error code << parameters.error_code >> and got $ERROR_CODE instead"; exit 1; fi
@@ -178,7 +177,7 @@ jobs:
 
             echo "Run the test"
             set +e
-            # the following line ensure that we are using the cached binary
+
             export CODACY_REPORTER_VERSION=$(cat .version)
             export CODACY_PROJECT_TOKEN='TEST_CODACY_PROJECT_TOKEN'
             export TEST_CODACY_REPORT_PATH='integration-tests/test_dotcover.xml'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,6 +218,7 @@ workflows:
       - codacy/sbt:
           name: scalafmt_and_compile
           cmd: sbt "scalafmt::test;test:scalafmt::test;sbt:scalafmt::test;test:compile;it:compile"
+          persist_to_workspace: true
           requires:
             - codacy/checkout_and_version
       - codacy/sbt:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,10 +29,10 @@ commands:
             set +e
             export CODACY_REPORTER_TMP_FOLDER=".codacy-coverage"
             mkdir -p $CODACY_REPORTER_TMP_FOLDER
-            cp "$HOME/workdir/artifacts/codacy-coverage-reporter-linux-$(cat $HOME/workdir/.version)" "$CODACY_REPORTER_TMP_FOLDER/codacy-coverage-reporter"
+            export CODACY_REPORTER_VERSION=$(cat .version)
+            cp "$HOME/workdir/artifacts/codacy-coverage-reporter-linux-$CODACY_REPORTER_VERSION" "$CODACY_REPORTER_TMP_FOLDER/$CODACY_REPORTER_VERSION/codacy-coverage-reporter"
             # the following line ensure that we are using the cached binary
-            export CODACY_REPORTER_VERSION=inexistent
-            << parameters.executor >> get.sh report --commit-uuid 'e9bef8a69a439bd601c37c0557277572425203a7'  -r $TEST_CODACY_REPORT_PATH --codacy-api-base-url http://localhost:1080
+            << parameters.executor >> get.sh report --commit-uuid 'e9bef8a69a439bd601c37c0557277572425203a7' -r $TEST_CODACY_REPORT_PATH --codacy-api-base-url http://localhost:1080
             export ERROR_CODE=$?
             if [ $ERROR_CODE -ne << parameters.error_code >> ]; then echo "expected an error code << parameters.error_code >> and got $ERROR_CODE instead"; exit 1; fi
             echo "test completed with the expected error code: << parameters.error_code >>"

--- a/docs/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/alternative-ways-of-running-coverage-reporter.md
@@ -128,12 +128,11 @@ Thanks to the amazing job of [Gavin Mogan](https://github.com/halkeye) you can n
 If you are using Travis CI to report coverage, update your file `.travis.yml` to include the following blocks:
 
 ```yaml
-before_install:
-  - sudo apt-get install jq
-  - curl -LSs "$(curl -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets | map({name, browser_download_url} | select(.name | endswith(".jar"))) | .[0].browser_download_url')" -o codacy-coverage-reporter-assembly.jar
+before_script:
+  - bash <(curl -Ls https://coverage.codacy.com/get.sh) download
 
 after_success:
-  - java -jar codacy-coverage-reporter-assembly.jar report -l Java -r build/reports/jacoco/test/jacocoTestReport.xml
+  - bash <(curl -Ls https://coverage.codacy.com/get.sh)
 ```
 
 Make sure that you also [set your project API Token](adding-coverage-to-your-repository.md#authenticate) as an environment variable in your Travis CI job.

--- a/get.sh
+++ b/get.sh
@@ -111,9 +111,9 @@ fi
 # Temporary folder for downloaded files
 if [ -z "$CODACY_REPORTER_TMP_FOLDER" ]; then
     if [ "$os_name" = "Linux" ]; then
-        CODACY_REPORTER_TMP_FOLDER="$HOME/.cache/codacy"
+        CODACY_REPORTER_TMP_FOLDER="$HOME/.cache/codacy/coverage-reporter"
     elif [ "$os_name" = "Darwin" ]; then
-        CODACY_REPORTER_TMP_FOLDER="$HOME/Library/Caches/Codacy"
+        CODACY_REPORTER_TMP_FOLDER="$HOME/Library/Caches/Codacy/coverage-reporter"
     else
         CODACY_REPORTER_TMP_FOLDER=".codacy-coverage"
     fi

--- a/get.sh
+++ b/get.sh
@@ -82,10 +82,10 @@ download_reporter() {
     if [ "$os_name" = "Linux" ] || [ "$os_name" = "Darwin" ]; then
         # OS name lower case
         suffix=$(echo "$os_name" | tr '[:upper:]' '[:lower:]')
-        local binary_name="codacy-coverage-reporter-$suffix"
     else
-        local binary_name="codacy-coverage-reporter-assembly.jar"
+        suffix="assembly.jar"
     fi
+    local binary_name="codacy-coverage-reporter-$suffix"
     local reporter_path=$1
 
     if [ ! -f "$reporter_path" ]

--- a/get.sh
+++ b/get.sh
@@ -65,24 +65,6 @@ exit_trap() {
 trap exit_trap EXIT
 trap 'fatal Interrupted' INT
 
-unamestr=$(uname)
-
-# Temporary folder for downloaded files
-if [ -z "$CODACY_REPORTER_TMP_FOLDER" ]; then
-    if [ "$unamestr" = "Linux" ]; then
-        CODACY_REPORTER_TMP_FOLDER="$HOME/.cache/codacy"
-    elif [ "$unamestr" = "Darwin" ]; then
-        CODACY_REPORTER_TMP_FOLDER="$HOME/Library/Caches/Codacy"
-    else
-        CODACY_REPORTER_TMP_FOLDER=".codacy-coverage"
-    fi
-fi
-mkdir -p "$CODACY_REPORTER_TMP_FOLDER"
-
-if [ -z "$CODACY_REPORTER_VERSION" ]; then
-    CODACY_REPORTER_VERSION="latest"
-fi
-
 download() {
     local url="$1"
     local output="${2:--}"
@@ -96,66 +78,83 @@ download() {
     fi
 }
 
-get_version() {
-    if [ "$CODACY_REPORTER_VERSION" == "latest" ]; then
-        bintray_latest_api_url="https://api.bintray.com/packages/codacy/Binaries/codacy-coverage-reporter/versions/_latest"
-        download $bintray_latest_api_url | sed -e 's/.*name[^0-9]*\([0-9]\{1,\}[.][0-9]\{1,\}[.][0-9]\{1,\}\).*/\1/'
+download_reporter() {
+    if [ "$os_name" = "Linux" ] || [ "$os_name" = "Darwin" ]; then
+        # OS name lower case
+        suffix=$(echo "$os_name" | tr '[:upper:]' '[:lower:]')
+        local binary_name="codacy-coverage-reporter-$suffix"
     else
-        echo "$CODACY_REPORTER_VERSION"
+        local binary_name="codacy-coverage-reporter-assembly.jar"
     fi
-}
+    local reporter_path=$1
 
-download_coverage_reporter() {
-    local binary_name=$1
-    local codacy_reporter=$2
-
-    if [ ! -f "$codacy_reporter" ]
+    if [ ! -f "$reporter_path" ]
     then
-        log "$i" "Download the codacy reporter $1... ($CODACY_REPORTER_VERSION)"
+        log "$i" "Downloading the codacy reporter $binary_name... ($CODACY_REPORTER_VERSION)"
 
-        bintray_api_url="https://dl.bintray.com/codacy/Binaries/$(get_version)/$binary_name"
+        bintray_api_url="https://dl.bintray.com/codacy/Binaries/$CODACY_REPORTER_VERSION/$binary_name"
 
-        download "$bintray_api_url" "$codacy_reporter"
+        download "$bintray_api_url" "$reporter_path"
     else
-        log "$i" "Using codacy reporter $1 from cache"
+        log "$i" "Codacy reporter $binary_name already in cache"
     fi
 }
 
-run() {
-    eval "$@"
-}
+os_name=$(uname)
 
-codacy_reporter_native_start_cmd() {
-    local suffix=$1
-    local codacy_reporter="$CODACY_REPORTER_TMP_FOLDER/codacy-coverage-reporter"
-    download_coverage_reporter "codacy-coverage-reporter-$suffix" "$codacy_reporter"
-    chmod +x $codacy_reporter
-    run_command="$codacy_reporter"
-}
+# Find the latest version in case is not specified
+if [ -z "$CODACY_REPORTER_VERSION" ]; then
+    bintray_latest_api_url="https://api.bintray.com/packages/codacy/Binaries/codacy-coverage-reporter/versions/_latest"
+    CODACY_REPORTER_VERSION=$(download $bintray_latest_api_url | sed -e 's/.*name[^0-9]*\([0-9]\{1,\}[.][0-9]\{1,\}[.][0-9]\{1,\}\).*/\1/')
+fi
 
-codacy_reporter_jar_start_cmd() {
-    local codacy_reporter="$CODACY_REPORTER_TMP_FOLDER/codacy-coverage-reporter-assembly.jar"
-    download_coverage_reporter "codacy-coverage-reporter-assembly.jar" "$codacy_reporter"
-    run_command="java -jar \"$codacy_reporter\""
-}
+# Temporary folder for downloaded files
+if [ -z "$CODACY_REPORTER_TMP_FOLDER" ]; then
+    if [ "$os_name" = "Linux" ]; then
+        CODACY_REPORTER_TMP_FOLDER="$HOME/.cache/codacy"
+    elif [ "$os_name" = "Darwin" ]; then
+        CODACY_REPORTER_TMP_FOLDER="$HOME/Library/Caches/Codacy"
+    else
+        CODACY_REPORTER_TMP_FOLDER=".codacy-coverage"
+    fi
+fi
 
-run_command=""
-if [ "$unamestr" = "Linux" ]; then
-    codacy_reporter_native_start_cmd "linux"
-elif [ "$unamestr" = "Darwin" ]; then
-    codacy_reporter_native_start_cmd "darwin"
+# Set binary name
+if [ "$os_name" = "Linux" ] || [ "$os_name" = "Darwin" ]; then
+    reporter_filename="codacy-coverage-reporter"
 else
-    codacy_reporter_jar_start_cmd
+    reporter_filename="codacy-coverage-reporter-assembly.jar"
+fi
+
+# Folder containing the binary
+reporter_folder="$CODACY_REPORTER_TMP_FOLDER"/"$CODACY_REPORTER_VERSION"
+
+# Create the reporter folder if not exists
+mkdir -p "$reporter_folder"
+
+# Set binary path
+reporter_path="$reporter_folder"/"$reporter_filename"
+
+download_reporter "$reporter_path"
+
+if [ "$os_name" = "Linux" ] || [ "$os_name" = "Darwin" ]; then
+    chmod +x "$reporter_path"
+    run_command="$reporter_path"
+else
+    run_command="java -jar \"$reporter_path\""
 fi
 
 if [ -z "$run_command" ]
 then
-    fatal "Codacy coverage reporter command could not be found."
+    fatal "Codacy coverage reporter binary could not be found."
 fi
 
-if [ "$#" -gt 0 ];
+if [ "$#" -eq 1 ] && [ "$1" = "download" ];
 then
-    run "$run_command $@"
+    log "$g" "Codacy reporter download succeded";
+elif [ "$#" -gt 0 ];
+then
+    eval "$run_command $*"
 else
-    run "$run_command \"report\""
+    eval "$run_command \"report\""
 fi


### PR DESCRIPTION
This PR started considering that in Travis CI the `after_success` phase runs after the cache has been saved.
So to cache the binary we need a separate phase that just downloads the binary without sending any coverage.
This also caches the binary based on the version so we're sure the binary gets updated when a new version is out.