### PR TITLE
fix: Drop API token integration tests

### DIFF
--- a/src/it/scala/com/codacy/CodacyCoverageReporterSpec.scala
+++ b/src/it/scala/com/codacy/CodacyCoverageReporterSpec.scala
@@ -9,11 +9,8 @@ import com.codacy.rules.ConfigurationRules
 import org.scalatest.{EitherValues, Matchers, WordSpec}
 
 class CodacyCoverageReporterSpec extends WordSpec with Matchers with EitherValues {
-  private val apiToken = sys.env.get("TEST_CODACY_API_TOKEN")
   private val projectToken = sys.env.get("TEST_CODACY_PROJECT_TOKEN")
   private val commitUuid = sys.env.get("TEST_COMMIT_UUID")
-  private val projectName = sys.env.get("TEST_PROJECT_NAME")
-  private val username = sys.env.get("TEST_USERNAME")
   private val apiBaseUrl = sys.env.get("TEST_BASE_API_URL")
 
   private def runCoverageReport(
@@ -50,25 +47,11 @@ class CodacyCoverageReporterSpec extends WordSpec with Matchers with EitherValue
 
         result shouldBe 'right
       }
-
-      "using an API token to send coverage" in {
-        // empty projectToken so we skip project token
-        // passing None will pick the token used for the codacy-coverage-reporter project
-        val result = runCoverageReport(None, apiToken, username, projectName, commitUuid)
-
-        result shouldBe 'right
-      }
     }
 
     "fail" when {
       "project token is invalid" in {
         val result = runCoverageReport(Some("invalid token"), None, None, None, commitUuid)
-
-        result shouldBe 'left
-      }
-
-      "API token is invalid" in {
-        val result = runCoverageReport(None, Some("invalid token"), username, projectName, commitUuid)
 
         result shouldBe 'left
       }


### PR DESCRIPTION
Integration tests using CODACY_API_TOKEN are not passing anymore
since the api token authentication is no more supported.