### PR TITLE
fix: Improve language guessing by stopping at first supported language CY-3145

### DIFF
--- a/src/main/scala/com/codacy/rules/ReportRules.scala
+++ b/src/main/scala/com/codacy/rules/ReportRules.scala
@@ -179,13 +179,9 @@ class ReportRules(coverageServices: => CoverageServices) extends LogSupport {
     languageOpt match {
       case Some(l) => Right(l)
       case None =>
-        report.fileReports.headOption match {
-          case None => Left("Can't guess the language due to empty coverage report")
-          case Some(fileReport) =>
-            Languages.forPath(fileReport.filename) match {
-              case None => Left("Can't guess the language due to invalid path")
-              case Some(value) => Right(value.toString)
-            }
+        report.fileReports.flatMap(file => Languages.forPath(file.filename)).headOption match {
+          case None => Left("Can't guess the report language")
+          case Some(value) => Right(value.name)
         }
     }
   }


### PR DESCRIPTION
Currently the behaviour is to fail guessing language if the first file has an extension we don't support.
This change makes the guesser continue to iterate on file until it finds a file for a language Codacy supports and uses that language file.
This is a temporary workaround until a more complete ( something like https://github.com/codacy/codacy-coverage-reporter/pull/269 ) lands.