### PR TITLE
doc: Refactor how to run Codacy Coverage Reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Follow the instructions on how to [add coverage to your repository](https://docs
 
 If necessary, see [alternative ways of running Codacy Coverage Reporter](https://docs.codacy.com/coverage-reporter/alternative-ways-of-running-coverage-reporter/) for other ways of running Codacy Coverage Reporter, such as by installing the binary manually or using a CircleCI Orb or GitHub Action.
 
+**NOTE: If you're using macOS Big Sur** you must [use the Java binary](https://docs.codacy.com/coverage-reporter/alternative-ways-of-running-coverage-reporter/#java) to run Codacy Coverage Reporter. For more details, see the issue [#276](https://github.com/codacy/codacy-coverage-reporter/issues/276).
+
 For a complete list of commands and options, run the Codacy Coverage Reporter with the flag `--help`. For example:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Multi-language coverage reporter for Codacy https://www.codacy.com
 
 Follow the instructions on how to [add coverage to your repository](https://docs.codacy.com/coverage-reporter/adding-coverage-to-your-repository/).
 
+If necessary, see [alternative ways of running Codacy Coverage Reporter](https://docs.codacy.com/coverage-reporter/alternative-ways-of-running-coverage-reporter/) for other ways of running Codacy Coverage Reporter, such as by installing the binary manually or using a CircleCI Orb or GitHub Action.
+
 For a complete list of commands and options, run the Codacy Coverage Reporter with the flag `--help`. For example:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -11,10 +11,35 @@ Multi-language coverage reporter for Codacy https://www.codacy.com
 
 Follow the instructions on how to [add coverage to your repository](https://docs.codacy.com/coverage-reporter/adding-coverage-to-your-repository/).
 
-For a complete list of commands and options, run:
+For a complete list of commands and options, run the Codacy Coverage Reporter with the flag `--help`. For example:
 
 ```bash
-bash <(curl -Ls https://coverage.codacy.com/get.sh) --help
+$ bash <(curl -Ls https://coverage.codacy.com/get.sh) report --help
+     ______          __
+    / ____/___  ____/ /___ ________  __
+   / /   / __ \/ __  / __ `/ ___/ / / /
+  / /___/ /_/ / /_/ / /_/ / /__/ /_/ /
+  \____/\____/\__,_/\__,_/\___/\__, /
+                              /____/
+
+  Codacy Coverage Reporter
+
+ --> Using codacy reporter codacy-coverage-reporter-linux from cache
+Command: report
+Usage: codacy-coverage-reporter report 
+  --project-token | -t  <your project API token>
+  --codacy-api-base-url  <the base URL for the Codacy API>
+  --commit-uuid  <your commitUUID>
+  --skip | -s  <skip if token isn't defined>
+  --language | -l  <your project language>
+  --coverage-reports | -r  <your project coverage file name>
+  --partial  <if the report is partial>
+  --prefix  <the project path prefix>
+  --force-coverage-parser  <your coverage parser>
+        Available parsers are: opencover,clover,lcov,phpunit,jacoco,dotcover,cobertura
+
+
+ --> Succeeded!
 ```
 
 ## What is Codacy?

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ Usage: codacy-coverage-reporter report
 ### Among Codacy’s features:
 
 - Identify new Static Analysis issues
-- Commit and Pull Request Analysis with GitHub, BitBucket/Stash, GitLab (and also direct git repositories)
+- Commit and Pull Request Analysis with GitHub, GitLab, and Bitbucket
 - Auto-comments on Commits and Pull Requests
-- Integrations with Slack, HipChat, Jira, YouTrack
-- Track issues Code Style, Security, Error Proneness, Performance, Unused Code and other categories
+- Integrations with Slack and Jira
+- Track issues in Code Style, Security, Error Proneness, Performance, Unused Code and other categories
 
 Codacy also helps keep track of Code Coverage, Code Duplication, and Code Complexity.
 

--- a/docs/adding-coverage-to-your-repository.md
+++ b/docs/adding-coverage-to-your-repository.md
@@ -49,6 +49,9 @@ After having coverage reports set up for your repository, you must use Codacy Co
 
     See [alternative ways of running Codacy Coverage Reporter](alternative-ways-of-running-coverage-reporter.md) for other ways of running Codacy Coverage Reporter, such as by installing the binary manually or using a CircleCI Orb or GitHub Action.
 
+    !!! warning
+        **If you're using macOS Big Sur** you must [use the Java binary](alternative-ways-of-running-coverage-reporter.md#java) to run Codacy Coverage Reporter. For more details, see the issue [#276](https://github.com/codacy/codacy-coverage-reporter/issues/276).
+
 1.  Optionally, [add a Codacy badge](https://docs.codacy.com/repositories/badges/) to the README of your repository to display the current code coverage.
 
 See the sections below for more advanced functionality.

--- a/docs/adding-coverage-to-your-repository.md
+++ b/docs/adding-coverage-to-your-repository.md
@@ -47,7 +47,7 @@ After having coverage reports set up for your repository, you must use Codacy Co
     bash <(curl -Ls https://coverage.codacy.com/get.sh) report
     ```
 
-    See [alternative ways of running Codacy Coverage Reporter](alternative-ways-of-running-coverage-reporter.md) for other ways of running Codacy Coverage Reporter, such as when using Circle CI or GitHub actions, or to install the binary manually.
+    See [alternative ways of running Codacy Coverage Reporter](alternative-ways-of-running-coverage-reporter.md) for other ways of running Codacy Coverage Reporter, such as by installing the binary manually or using a CircleCI Orb or GitHub Action.
 
 1.  Optionally, [add a Codacy badge](https://docs.codacy.com/repositories/badges/) to the README of your repository to display the current code coverage.
 

--- a/docs/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/alternative-ways-of-running-coverage-reporter.md
@@ -14,6 +14,9 @@ The recommended way to run Codacy Coverage Reporter is using a self-contained sc
     wget -qO - https://coverage.codacy.com/get.sh | sh
     ```
 
+!!! warning
+    **If you're using macOS Big Sur** you must [use the Java binary](#java) to run Codacy Coverage Reporter. For more details, see the issue [#276](https://github.com/codacy/codacy-coverage-reporter/issues/276).
+
 The self-contained script can cache the binary. To avoid downloading the binary every time that the script runs, add one of the following directories to your CI cached folders:
 
 -   `$HOME/.cache/codacy` on Linux

--- a/docs/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/alternative-ways-of-running-coverage-reporter.md
@@ -1,20 +1,20 @@
 # Alternative ways of running Coverage Reporter
 
-The recommended way to run Codacy Coverage Reporter is using a self-contained script that automatically downloads and runs the most recent version of Codacy Coverage Reporter.
+The recommended way to run Codacy Coverage Reporter is using a self-contained script that automatically downloads and runs the most recent version of Codacy Coverage Reporter:
 
-On Ubuntu, run:
+-   On Ubuntu, run:
 
-```bash
-bash <(curl -Ls https://coverage.codacy.com/get.sh)
-```
+    ```bash
+    bash <(curl -Ls https://coverage.codacy.com/get.sh)
+    ```
 
-On Alpine Linux, run:
+-   On Alpine Linux, run:
 
-```sh
-wget -qO - https://coverage.codacy.com/get.sh | sh
-```
+    ```sh
+    wget -qO - https://coverage.codacy.com/get.sh | sh
+    ```
 
-The self-contained script is able to cache the binary. To avoid downloading the binary every time that the script runs, add one of the following directories to your CI cached folders:
+The self-contained script can cache the binary. To avoid downloading the binary every time that the script runs, add one of the following directories to your CI cached folders:
 
 -   `$HOME/.cache/codacy` on Linux
 -   `$HOME/Library/Caches/Codacy` on Mac OS X
@@ -26,6 +26,77 @@ export CODACY_REPORTER_VERSION=<version>
 ```
 
 The sections below provide details on alternative ways to run or install Codacy Coverage Reporter.
+
+## Manually downloading the binary
+
+### Linux amd64
+
+If you prefer, you can manually download and run the native `codacy-coverage-reporter` binary, either for the latest version or a specific one.
+
+You can use the scripts below to automatically check for the latest version of the binaries, download the binaries from either Bintray or GitHub, and run them.
+
+-   Using Bintray:
+
+    ```bash
+    LATEST_VERSION="$(curl -Ls https://api.bintray.com/packages/codacy/Binaries/codacy-coverage-reporter/versions/_latest | jq -r .name)"
+    curl -Ls -o codacy-coverage-reporter "https://dl.bintray.com/codacy/Binaries/${LATEST_VERSION}/codacy-coverage-reporter-linux"
+    chmod +x codacy-coverage-reporter
+    ./codacy-coverage-reporter report
+    ```
+
+-   Using GitHub:
+
+    ```bash
+    curl -Ls -o codacy-coverage-reporter "$(curl -Ls https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets | map({name, browser_download_url} | select(.name | contains("codacy-coverage-reporter-linux"))) | .[0].browser_download_url')"
+    chmod +x codacy-coverage-reporter
+    ./codacy-coverage-reporter report
+    ```
+
+### Java
+
+Use the Java binary to run Codacy Coverage reporter on other platforms, such as Linux x86, macOS, Windows, etc.
+
+You can use the scripts below to automatically check for the latest version of the Java binaries, download the binaries from either Bintray or GitHub, and run them.
+
+-   Using Bintray:
+
+    ```bash
+    LATEST_VERSION="$(curl -Ls https://api.bintray.com/packages/codacy/Binaries/codacy-coverage-reporter/versions/_latest | jq -r .name)"
+    curl -Ls -o codacy-coverage-reporter-assembly.jar "https://dl.bintray.com/codacy/Binaries/${LATEST_VERSION}/codacy-coverage-reporter-assembly.jar"
+    java -jar codacy-coverage-reporter-assembly.jar report
+    ```
+
+-   Using GitHub:
+
+    ```bash
+    curl -LS -o codacy-coverage-reporter-assembly.jar "$(curl -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets | map({name, browser_download_url} | select(.name | endswith(".jar"))) | .[0].browser_download_url')"
+    java -jar codacy-coverage-reporter-assembly.jar report
+    ```
+
+## Building from source
+
+If you are having any issues with your installation, you can also build the coverage reporter from source.
+
+1.  Clone the Codacy Coverage Reporter repository:
+
+    ```bash
+    git clone https://github.com/codacy/codacy-coverage-reporter.git
+    ```
+
+1.  Run the command `sbt assembly` inside the local repository folder:
+
+    ```bash
+    cd codacy-coverage-reporter
+    sbt assembly
+    ```
+   
+    This will produce a file `target/codacy-coverage-reporter-assembly-<version>.jar` that you can run.
+
+1.  Execute this `.jar` in the repository where you want to upload the coverage. For example:
+
+    ```bash
+    <path>/java-project$ java -jar ../codacy-coverage-reporter/target/codacy-coverage-reporter-assembly-<version>.jar report
+    ```
 
 ## CircleCI orb
 
@@ -114,72 +185,3 @@ task sendCoverageToCodacy(type: JavaExec, dependsOn: jacocoTestReport) {
     ]
 }
 ```
-
-## Manually downloading the native Linux amd64 binary
-
-If you prefer, you can manually download and run the native `codacy-coverage-reporter` binary, either for the latest version or a specific one.
-
-You can use the scripts below to automatically check for the latest version of the binaries, download the binaries from either Bintray or GitHub, and run them.
-
-Using Bintray:
-
-```bash
-LATEST_VERSION="$(curl -Ls https://api.bintray.com/packages/codacy/Binaries/codacy-coverage-reporter/versions/_latest | jq -r .name)"
-curl -Ls -o codacy-coverage-reporter "https://dl.bintray.com/codacy/Binaries/${LATEST_VERSION}/codacy-coverage-reporter-linux"
-chmod +x codacy-coverage-reporter
-./codacy-coverage-reporter report
-```
-
-Using GitHub:
-
-```bash
-curl -Ls -o codacy-coverage-reporter "$(curl -Ls https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets | map({name, browser_download_url} | select(.name | contains("codacy-coverage-reporter-linux"))) | .[0].browser_download_url')"
-chmod +x codacy-coverage-reporter
-./codacy-coverage-reporter report
-```
-
-## Manually downloading the Java binary
-
-Use the Java binary to run Codacy Coverage reporter on other platforms, such as Linux x86, MacOS, Windows, etc.
-
-You can use the scripts below to automatically check for the latest version of the Java binaries, download the binaries from either Bintray or GitHub, and run them.
-
-Using Bintray:
-
-```bash
-LATEST_VERSION="$(curl -Ls https://api.bintray.com/packages/codacy/Binaries/codacy-coverage-reporter/versions/_latest | jq -r .name)"
-curl -Ls -o codacy-coverage-reporter-assembly.jar "https://dl.bintray.com/codacy/Binaries/${LATEST_VERSION}/codacy-coverage-reporter-assembly.jar"
-java -jar codacy-coverage-reporter-assembly.jar report
-```
-
-Using GitHub:
-
-```bash
-curl -LS -o codacy-coverage-reporter-assembly.jar "$(curl -LSs https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r '.assets | map({name, browser_download_url} | select(.name | endswith(".jar"))) | .[0].browser_download_url')"
-java -jar codacy-coverage-reporter-assembly.jar report
-```
-
-## Building from source
-
-If you are having any issues with your installation, you can also build the coverage reporter from source.
-
-1.  Clone the Codacy Coverage Reporter repository:
-
-    ```bash
-    git clone https://github.com/codacy/codacy-coverage-reporter.git
-    ```
-
-1.  Run the command `sbt assembly` inside the local repository folder:
-
-    ```bash
-    cd codacy-coverage-reporter
-    sbt assembly
-    ```
-   
-    This will produce a file `target/codacy-coverage-reporter-assembly-<version>.jar` that you can run.
-
-1.  Execute this `.jar` in the repository where you want to upload the coverage. For example:
-
-    ```bash
-    <path>/java-project$ java -jar ../codacy-coverage-reporter/target/codacy-coverage-reporter-assembly-<version>.jar report
-    ```


### PR DESCRIPTION
Currently, from the README it's not very clear that there are multiple ways to run the Codacy Coverage Reporter. In particular, users who cannot run the Coverage Reporter on macOS Big Sur have trouble figuring out that they can use the Java binary as a workaround.

See https://github.com/codacy/codacy-coverage-reporter/issues/276 and [CY-3404](https://codacy.atlassian.net/browse/CY-3404) for more details.