### PR TITLE
fix: Strip trailing "/" from CODACY_API_BASE_URL environment variable

### DIFF
--- a/src/main/scala/com/codacy/rules/ConfigurationRules.scala
+++ b/src/main/scala/com/codacy/rules/ConfigurationRules.scala
@@ -77,7 +77,7 @@ class ConfigurationRules(cmdConfig: CommandConfiguration, envVars: Map[String, S
       commitUUID <- validateCommitUUIDConfig(baseConfig)
       baseConf = BaseConfig(
         authConfig,
-        baseConfig.codacyApiBaseUrl.getOrElse(getApiBaseUrl),
+        baseConfig.codacyApiBaseUrl.getOrElse(getApiBaseUrl).replaceAll("/$", ""),
         commitUUID,
         baseConfig.debugValue
       )


### PR DESCRIPTION
On https://github.com/codacy/docs/issues/404 a user noticed that the upload fails if the defined `CODACY_API_BASE_URL` environment variable includes a trailing slash character (`/`).

This is a "quick and dirty" suggestion to make the Codacy Coverage Reporter work both in this scenario and also when the base URL is specified with the flag `--codacy-api-base-url`.