### PR TITLE
fix: Update missing dotCover detailedXML report format

### DIFF
--- a/docs/adding-coverage-to-your-repository.md
+++ b/docs/adding-coverage-to-your-repository.md
@@ -8,7 +8,7 @@ Codacy supports the following coverage report formats:
 | ----------------------------- | ---------------------------- |
 | Clover                        | clover.xml                   |
 | Cobertura                     | cobertura.xml                |
-| dotCover XML                  | dotcover.xml                 |
+| dotCover detailedXML          | dotcover.xml                 |
 | JaCoCo                        | jacoco\*.xml                 |
 | LCOV                          | lcov.info, lcov.dat, \*.lcov |
 | OpenCover                     | opencover.xml                |


### PR DESCRIPTION
The previous pull request https://github.com/codacy/codacy-coverage-reporter/pull/284 failed to update this page.