### PR TITLE
bump: Bump codacy-api-scala to 5.0.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,7 +86,7 @@ lazy val coverageParser = project
   .in(file("coverage-parser"))
   .settings(
     libraryDependencies ++= Seq(
-      "com.codacy" %% "codacy-api-scala" % "5.0.0",
+      "com.codacy" %% "codacy-api-scala" % "5.0.1",
       "com.codacy" %% "codacy-plugins-api" % "5.2.0",
       "org.scala-lang.modules" %% "scala-xml" % "1.2.0",
       scalatest % Test


### PR DESCRIPTION
Includes the changes from https://github.com/codacy/codacy-api-scala/pull/42.