### PR TITLE
feature: publish to s3 instead of bintray

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,9 +317,9 @@ workflows:
               only:
                 - master
       - codacy/publish_s3:
-          name: publish_bintray	          
-          path: binaries/codacy-coverage-reporter
-          files: artifacts/codacy-coverage-reporter-linux artifacts/codacy-coverage-reporter-darwin artifacts/codacy-coverage-reporter-assembly.jar	          
+          name: publish_bintray
+          path: bin/codacy-coverage-reporter
+          files: artifacts/codacy-coverage-reporter-linux artifacts/codacy-coverage-reporter-darwin artifacts/codacy-coverage-reporter-assembly.jar
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ jobs:
             export CODACY_REPORTER_TMP_FOLDER=".codacy-coverage"
             version=$(cat .version)
             mkdir -p $CODACY_REPORTER_TMP_FOLDER/$version
-            cp $HOME/workdir/artifacts/codacy-coverage-reporter-darwin-$version $CODACY_REPORTER_TMP_FOLDER/$version/codacy-coverage-reporter
+            cp $HOME/workdir/artifacts/codacy-coverage-reporter-darwin $CODACY_REPORTER_TMP_FOLDER/$version/codacy-coverage-reporter
       - run:
           name: test on osx
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@2.12.1
+  codacy: codacy/base@5.2.0
 
 references:
   circleci_job: &circleci_job
@@ -30,7 +30,7 @@ commands:
             export CODACY_REPORTER_TMP_FOLDER=".codacy-coverage"
             export CODACY_REPORTER_VERSION=$(cat .version)
             mkdir -p $CODACY_REPORTER_TMP_FOLDER/$CODACY_REPORTER_VERSION
-            cp "$HOME/workdir/artifacts/codacy-coverage-reporter-linux-$CODACY_REPORTER_VERSION" "$CODACY_REPORTER_TMP_FOLDER/$CODACY_REPORTER_VERSION/codacy-coverage-reporter"
+            cp "$HOME/workdir/artifacts/codacy-coverage-reporter-linux" "$CODACY_REPORTER_TMP_FOLDER/$CODACY_REPORTER_VERSION/codacy-coverage-reporter"
             << parameters.executor >> get.sh report --commit-uuid 'e9bef8a69a439bd601c37c0557277572425203a7' -r $TEST_CODACY_REPORT_PATH --codacy-api-base-url http://localhost:1080
             export ERROR_CODE=$?
             if [ $ERROR_CODE -ne << parameters.error_code >> ]; then echo "expected an error code << parameters.error_code >> and got $ERROR_CODE instead"; exit 1; fi
@@ -94,12 +94,12 @@ jobs:
           at: ~/workdir
       - run: |
           mkdir -p ~/workdir/artifacts/
-          mv ~/workdir/tmp-artifacts/codacy-coverage-reporter-assembly-$(cat .version).jar ~/workdir/artifacts/
-          upx --lzma -o ~/workdir/artifacts/codacy-coverage-reporter-linux-$(cat .version) ~/workdir/tmp-artifacts/codacy-coverage-reporter-linux
+          mv ~/workdir/tmp-artifacts/codacy-coverage-reporter-assembly.jar ~/workdir/artifacts/codacy-coverage-reporter-assembly.jar
+          upx --lzma -o ~/workdir/artifacts/codacy-coverage-reporter-linux ~/workdir/tmp-artifacts/codacy-coverage-reporter-linux
           # upx binaries don't work on Mac OS Big Sur https://github.com/upx/upx/issues/424
           # use upx again once the bug is fixed
-          # upx --lzma -o ~/workdir/artifacts/codacy-coverage-reporter-darwin-$(cat .version) ~/workdir/tmp-artifacts/codacy-coverage-reporter-darwin
-          cp ~/workdir/tmp-artifacts/codacy-coverage-reporter-darwin ~/workdir/artifacts/codacy-coverage-reporter-darwin-$(cat .version)
+          # upx --lzma -o ~/workdir/artifacts/codacy-coverage-reporter-darwin ~/workdir/tmp-artifacts/codacy-coverage-reporter-darwin
+          cp ~/workdir/tmp-artifacts/codacy-coverage-reporter-darwin ~/workdir/artifacts/codacy-coverage-reporter-darwin
       - persist_to_workspace:
           root: ~/workdir
           paths:
@@ -241,7 +241,7 @@ workflows:
             sbt "assembly;graalvm-native-image:packageBin"
             mkdir -p ~/workdir/tmp-artifacts
             mv target/graalvm-native-image/codacy-coverage-reporter ~/workdir/tmp-artifacts/codacy-coverage-reporter-linux
-            mv target/codacy-coverage-reporter-assembly-$(cat .version).jar ~/workdir/tmp-artifacts
+            mv target/codacy-coverage-reporter-assembly-$(cat .version).jar ~/workdir/tmp-artifacts/codacy-coverage-reporter-assembly.jar
           persist_to_workspace: true
           requires:
             - scalafmt_and_compile
@@ -292,7 +292,7 @@ workflows:
           name: build_publish_docker_image
           context: CodacyDocker
           cmd: |
-            docker build --build-arg nativeImageLocation=artifacts/codacy-coverage-reporter-linux-$(cat .version) -t codacy-coverage-reporter .
+            docker build --build-arg nativeImageLocation=artifacts/codacy-coverage-reporter-linux -t codacy-coverage-reporter .
             docker tag codacy-coverage-reporter codacy/$CIRCLE_PROJECT_REPONAME:$(cat .version)
             docker login -u $DOCKER_USER -p $DOCKER_PASS
             docker push codacy/$CIRCLE_PROJECT_REPONAME:$(cat .version)
@@ -316,19 +316,15 @@ workflows:
             branches:
               only:
                 - master
-      #TODO: Add bintray orb
-      - codacy/shell:
-          name: publish_bintray
-          cmd: |
-            curl -T ~/workdir/artifacts/codacy-coverage-reporter-linux-$(cat .version) -ucodacy-ci:$BINTRAY_API_KEY -H "X-Bintray-Package:codacy-coverage-reporter" -H "X-Bintray-Version:$(cat .version)" https://api.bintray.com/content/codacy/Binaries/$(cat .version)/codacy-coverage-reporter-linux
-            curl -T ~/workdir/artifacts/codacy-coverage-reporter-darwin-$(cat .version) -ucodacy-ci:$BINTRAY_API_KEY -H "X-Bintray-Package:codacy-coverage-reporter" -H "X-Bintray-Version:$(cat .version)" https://api.bintray.com/content/codacy/Binaries/$(cat .version)/codacy-coverage-reporter-darwin
-            curl -T ~/workdir/artifacts/codacy-coverage-reporter-assembly-$(cat .version).jar -ucodacy-ci:$BINTRAY_API_KEY -H "X-Bintray-Package:codacy-coverage-reporter" -H "X-Bintray-Version:$(cat .version)" https://api.bintray.com/content/codacy/Binaries/$(cat .version)/codacy-coverage-reporter-assembly.jar
-            curl -X POST -ucodacy-ci:$BINTRAY_API_KEY https://api.bintray.com/content/codacy/Binaries/codacy-coverage-reporter/$(cat .version)/publish
+      - codacy/publish_s3:
+          name: publish_bintray	          
+          path: binaries/codacy-coverage-reporter
+          files: artifacts/codacy-coverage-reporter-linux artifacts/codacy-coverage-reporter-darwin artifacts/codacy-coverage-reporter-assembly.jar	          
           filters:
             branches:
               only:
                 - master
-          context: CodacyBintray
+          context: CodacyAWS
           requires:
             - it_coverage_script_macosx
             - it_coverage_script_alpine


### PR DESCRIPTION
This is a 2 step process:

1. start publishing to bintray (this PR)
2. change get.sh script to retrieve from public s3 (coming soon...)

This will guarantee that the script usages will have no downtime