### PR TITLE
feature: Add workaround for MalformedInputException DOCS-217

### DIFF
--- a/docs/troubleshooting-common-issues.md
+++ b/docs/troubleshooting-common-issues.md
@@ -69,6 +69,12 @@ dotCover.exe cover ... /Filters=-:xunit*
 
 By default, dotCover includes xUnit files in the coverage analysis and this results in larger coverage reports. This filter helps ensure that the resulting coverage data does not exceed the size limit accepted by the Codacy API when uploading the results.
 
+## MalformedInputException while parsing report
+
+If you get a `java.nio.charset.MalformedInputException` when running the Codacy Coverage Reporter it means that the coverage report includes an unsupported character, perhaps on one of your source code file names.
+
+For maximum compatibility of your coverage reports with the Codacy Coverage Reporter, make sure that your coverage reports use UTF-8 encoding or remove any special characters from the reports.
+
 ## SubstrateSegfaultHandler caught signal 11
 
 If you are experiencing segmentation faults when uploading the coverage results due to [oracle/graal#624](https://github.com/oracle/graal/issues/624), execute the following command before running the reporter, as a workaround:


### PR DESCRIPTION
After the investigation in [CY-3801](https://codacy.atlassian.net/browse/CY-3801) we came to the conclusion that the recommended workaround for [this issue](https://community.codacy.com/t/issue-getting-malformedinputexception-input-length-1-when-uploading-lcov-info-from-github-actions/181) would be to make sure that the coverage report is encoded using UTF-8.