### PR TITLE
doc: Add simplified way of uploading multiple coverage reports

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -154,7 +154,7 @@ bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
     -l Java -r report1.xml -r report2.xml -r report3.xml
 ```
 
-You can also specify the reports to upload dynamically using the command `find`. For example:
+You can also upload all your reports dynamically using the command `find`. For example:
 
 ```bash
 bash <(curl -Ls https://coverage.codacy.com/get.sh) report \

--- a/docs/index.md
+++ b/docs/index.md
@@ -145,28 +145,34 @@ See the sections below for more advanced functionality, or [check the troublesho
 
 ## Uploading multiple coverage reports for the same language {: id="multiple-reports"}
 
-If your test suite is split on different modules or runs in parallel, you will need to upload multiple coverage reports for the same language:
+If your test suite is split on different modules or runs in parallel, you will need to upload multiple coverage reports for the same language.
 
-1.  Upload each separate report with the following flags:
-
-    - `--partial`
-    - `-l <language>`
-    - `-r <partial report>`
-
-2.  After uploading all reports, notify Codacy with the `final` command.
-
-For example:
+To do this, specify multiple reports by repeating the flag `-r`. For example:
 
 ```bash
 bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
-    --partial -l Java -r report1.xml
-bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
-    --partial -l Java -r report2.xml
-bash <(curl -Ls https://coverage.codacy.com/get.sh) final
+    -l Java -r report1.xml -r report2.xml -r report3.xml
 ```
 
-!!! important
-    If you are sending reports for a language with the flag `--partial`, you should use the flag in all reports for that language to ensure the correct calculation of the coverage.
+You can also specify the reports to upload dynamically using the command `find`. For example:
+
+```bash
+bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
+    -l Java $(find **/jacoco*.xml -printf '-r %p ')
+```
+
+!!! note
+    Altenatively, you can upload each report separately with the flag `--partial` and notify Codacy with the `final` command after uploading all reports. For example:
+
+    ```bash
+    bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
+        --partial -l Java -r report1.xml
+    bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
+        --partial -l Java -r report2.xml
+    bash <(curl -Ls https://coverage.codacy.com/get.sh) final
+    ```
+
+    If you're sending reports for a language with the flag `--partial`, you should use the flag in all reports for that language to ensure the correct calculation of the coverage.
 
 !!! tip
     It might also be possible to merge the reports before uploading them to Codacy, since most coverage tools support merge/aggregation. For example, <http://www.eclemma.org/jacoco/trunk/doc/merge-mojo.html>.


### PR DESCRIPTION
It's possible to upload multiple test coverage reports using a single command. This also makes it easier to find and specify multiple report files dynamically.

:construction: **Should we keep the information in red or is it just adding unnecessary complexity in the documentation?** Plase see the comments below.

![image](https://user-images.githubusercontent.com/60105800/111988371-54954500-8b08-11eb-9b14-a673da5f67c8.png)

See [this Slack thread](https://codacy.slack.com/archives/C8X9SS1H7/p1615805679001700) for more details.