### PR TITLE
doc: Simplify instructions on uploading multiple coverage reports DOCS-228

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -159,7 +159,7 @@ bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
 ```
 
 !!! tip
-    You can also upload all your reports dynamically using the command `find`. For example:
+    You can also find and upload all your reports dynamically using the command `find` with a regular expression. For example:
 
     ```bash
     bash <(curl -Ls https://coverage.codacy.com/get.sh) report \

--- a/docs/index.md
+++ b/docs/index.md
@@ -158,25 +158,13 @@ bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
     -l Java -r report1.xml -r report2.xml -r report3.xml
 ```
 
-You can also upload all your reports dynamically using the command `find`. For example:
-
-```bash
-bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
-    -l Java $(find **/jacoco*.xml -printf '-r %p ')
-```
-
-!!! note
-    Altenatively, you can upload each report separately with the flag `--partial` and notify Codacy with the `final` command after uploading all reports. For example:
+!!! tip
+    You can also upload all your reports dynamically using the command `find`. For example:
 
     ```bash
     bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
-        --partial -l Java -r report1.xml
-    bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
-        --partial -l Java -r report2.xml
-    bash <(curl -Ls https://coverage.codacy.com/get.sh) final
+        -l Java $(find **/jacoco*.xml -printf '-r %p ')
     ```
-
-    If you're sending reports for a language with the flag `--partial`, you should use the flag in all reports for that language to ensure the correct calculation of the coverage.
 
 !!! tip
     It might also be possible to merge the reports before uploading them to Codacy, since most coverage tools support merge/aggregation. For example, <http://www.eclemma.org/jacoco/trunk/doc/merge-mojo.html>.


### PR DESCRIPTION
After adding instructions on uploading multiple coverage reports using a single command (#304), I propose that we simplify the documentation by removing the instructions for the `--partial` + `final` method, **as long as there isn't a good reason** why customers would need or prefer to upload coverage reports using this method.

Here's a preview of the proposed solution:

![image](https://user-images.githubusercontent.com/60105800/112336237-d0cc8b80-8cb4-11eb-8910-516c1d55040c.png)
