### PR TITLE
doc: Add meta descriptions to documentation pages DOCS-227

### DIFF
--- a/docs/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/alternative-ways-of-running-coverage-reporter.md
@@ -1,3 +1,7 @@
+---
+description: Alternative ways of running or installing Codacy Coverage Reporter including running a Docker image, downloading a binary for your operating system, or building the binary from source.
+---
+
 # Alternative ways of running Coverage Reporter
 
 The recommended way to run Codacy Coverage Reporter is using a self-contained script that automatically downloads and runs the most recent version of Codacy Coverage Reporter:

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,10 @@
+---
+description: To set up coverage on Codacy you must generate coverage reports in a supported format and upload them to Codacy.
+---
+
 # Adding coverage to your repository
 
-Code coverage is a metric used to describe the degree to which the source code of a program is tested. A program with high code coverage has been more thoroughly tested and has a lower chance of containing software bugs than a program with low code coverage. You can read more about the [basics of code coverage](https://blog.codacy.com/a-guide-to-code-coverage-part-1-code-coverage-explained/) on our blog.
+Code coverage is a metric used to describe the degree to which the source code of a program is tested. A program with high code coverage has been more thoroughly tested and has a lower chance of containing software bugs than a program with low code coverage. You can read more about the [basics of code coverage](https://blog.codacy.com/a-guide-to-code-coverage-part-1-code-coverage-explained/) on Codacy's blog.
 
 To set up coverage on Codacy you must complete these main steps:
 

--- a/docs/troubleshooting-common-issues.md
+++ b/docs/troubleshooting-common-issues.md
@@ -1,3 +1,7 @@
+---
+description: Instructions or workarounds to overcome common issues while using Codacy Coverage Reporter.
+---
+
 # Troubleshooting common issues
 
 The sections below provide instructions or workarounds to overcome common issues while using Codacy Coverage Reporter.


### PR DESCRIPTION
Add explicit meta descriptions to each documentation page, necessary to complete https://github.com/codacy/docs/pull/585.