### PR TITLE
bump: Update codacy/base orb to latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,6 +162,9 @@ jobs:
       - run:
           name: prepare the environment
           command: |
+            # Call brew update explicitly until Circle CI update their images,
+            # see https://github.com/Homebrew/brew/issues/11123
+            brew update
             brew install mockserver coreutils
             export CODACY_REPORTER_TMP_FOLDER=".codacy-coverage"
             version=$(cat .version)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@5.2.0
+  codacy: codacy/base@5.2.3
 
 references:
   circleci_job: &circleci_job


### PR DESCRIPTION
Includes the fix from https://github.com/codacy/codacy-orbs/pull/146 and applies the same fix to the job `it_coverage_script_macosx`.