### PR TITLE
doc: Improve meta descriptions of top searched pages DOCS-227

### DIFF
--- a/docs/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/alternative-ways-of-running-coverage-reporter.md
@@ -1,5 +1,5 @@
 ---
-description: Alternative ways of running or installing Codacy Coverage Reporter including running a Docker image, downloading a binary for your operating system, or building the binary from source.
+description: There are alternative ways of running or installing Codacy Coverage Reporter, such as running a Docker image, downloading a binary for your operating system, or building the binary from source.
 ---
 
 # Alternative ways of running Coverage Reporter

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,12 @@
 ---
-description: To set up coverage on Codacy you must generate coverage reports in a supported format and upload them to Codacy.
+description: Generate coverage reports in a supported format and upload them to Codacy to monitor the test coverage of your repositories on Codacy.
 ---
 
 # Adding coverage to your repository
 
 Code coverage is a metric used to describe the degree to which the source code of a program is tested. A program with high code coverage has been more thoroughly tested and has a lower chance of containing software bugs than a program with low code coverage. You can read more about the [basics of code coverage](https://blog.codacy.com/a-guide-to-code-coverage-part-1-code-coverage-explained/) on Codacy's blog.
 
-To set up coverage on Codacy you must complete these main steps:
+Complete these main steps to start monitoring the test coverage of your repositories on Codacy:
 
 1.  **Generating coverage reports**
 


### PR DESCRIPTION
Review and curate the meta descriptions of the [top landing pages for Google searches](https://docs.google.com/spreadsheets/d/191E8aGjiJwpSp8sroPZQUeZMmSiJ7t2HHLFGnJvkhEE/edit#gid=566714567).