### PR TITLE
doc: Improve links to instructions on obtaining API tokens

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -115,7 +115,7 @@ After having coverage reports set up for your repository, you must use Codacy Co
 1.  Set up an API token to allow Codacy Coverage Reporter to authenticate on Codacy.
     {: id="authenticate"}
 
-    -   **If you're setting up coverage for one repository**, obtain the [project API Token](../codacy-api/api-tokens/#project-api-tokens) from the page **Integrations** in your Codacy repository settings.
+    -   **If you're setting up coverage for one repository**, [obtain a project API Token](../codacy-api/api-tokens/#project-api-tokens) from the page **Integrations** in your Codacy repository settings.
 
         Then, set the following environment variable to specify your project API Token:
 
@@ -123,7 +123,7 @@ After having coverage reports set up for your repository, you must use Codacy Co
         export CODACY_PROJECT_TOKEN=<your project API Token>
         ```
 
-    -   **If you're setting up and automating coverage for multiple repositories**, obtain an [account API Token](../codacy-api/api-tokens/#account-api-tokens) from the page **Access management** in your Codacy account settings.
+    -   **If you're setting up and automating coverage for multiple repositories**, [obtain an account API Token](../codacy-api/api-tokens/#account-api-tokens) from the page **Access management** in your Codacy account settings.
 
         Then, set the following environment variables to specify the account API Token, the username associated with the account API token, and the repository for which you're uploading the coverage information:
 


### PR DESCRIPTION
Small improvement to make the links to instructions on how to obtain API tokens more actionable.