### PR TITLE
Fixing flag description for Api-Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ bash <(curl -Ls https://coverage.codacy.com/get.sh) report --help
 Command: report
 Usage: codacy-coverage-reporter report 
   --project-token | -t  <your project API token>
-  --api-token | -t  <your account API token>
+  --api-token | -a  <your account API token>
   --organization-provider  <the project organization provider> (manual, gh, bb, ghe, bbe, gl, gle)
   --username | -u  <the project owner name>
   --project-name | -p  <your project name>


### PR DESCRIPTION
A customer was having issues with using the api-token when reporting coverage. Turns out he was using the '-t' flag and it looks like we had a typo in the README.