### PR TITLE
doc: Fix broken link to PHPUnit documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ There are many tools that you can use to generate coverage reports for the langu
 </tr>
 <tr>
     <td>PHP</td>
-    <td><a href="https://phpunit.readthedocs.io/en/9.3/code-coverage-analysis.html">PHPUnit</a></td>
+    <td><a href="https://phpunit.readthedocs.io/en/stable/code-coverage-analysis.html">PHPUnit</a></td>
     <td><code>coverage-xml/index.xml</code> (PHPUnit XML version &lt;= 4)<br/>
         <code>clover.xml</code> (Clover)</td>
 </tr>


### PR DESCRIPTION
Fixes https://github.com/codacy/docs/issues/685.