### PR TITLE
feature: Add --http-timeout option for custom timeouts when interacting with Codacy API CY-4834

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Usage: codacy-coverage-reporter report
   --project-name | -p  <your project name>
   --codacy-api-base-url  <the base URL for the Codacy API>
   --commit-uuid  <your commitUUID>
+  --http-timeout  <Sets a specified timeout value, in milliseconds, to be used when interacting with Codacy API>
   --skip | -s  <skip if token isn't defined>
   --language | -l  <your project language>
   --coverage-reports | -r  <your project coverage file name>

--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,7 @@ lazy val coverageParser = project
   .in(file("coverage-parser"))
   .settings(
     libraryDependencies ++= Seq(
-      "com.codacy" %% "codacy-api-scala" % "6.0.0",
+      "com.codacy" %% "codacy-api-scala" % "6.1.0",
       "com.codacy" %% "codacy-plugins-api" % "5.2.0",
       "org.scala-lang.modules" %% "scala-xml" % "1.2.0",
       scalatest % Test

--- a/src/it/scala/com/codacy/CodacyCoverageReporterSpec.scala
+++ b/src/it/scala/com/codacy/CodacyCoverageReporterSpec.scala
@@ -1,13 +1,13 @@
 package com.codacy
 
-import java.io.File
-
 import com.codacy.api.OrganizationProvider
 import com.codacy.configuration.parser.{BaseCommandConfig, Report}
 import com.codacy.di.Components
 import com.codacy.model.configuration.ReportConfig
 import com.codacy.rules.ConfigurationRules
 import org.scalatest.{EitherValues, Matchers, WordSpec}
+
+import java.io.File
 
 class CodacyCoverageReporterSpec extends WordSpec with Matchers with EitherValues {
   private val apiToken = sys.env.get("TEST_CODACY_API_TOKEN")
@@ -23,10 +23,20 @@ class CodacyCoverageReporterSpec extends WordSpec with Matchers with EitherValue
       organizationProvider: Option[OrganizationProvider.Value],
       username: Option[String],
       projectName: Option[String],
-      commitUuid: Option[String]
+      commitUuid: Option[String],
+      httpTimeout: Option[Int] = None
   ) = {
     val baseConfig =
-      BaseCommandConfig(projectToken, apiToken, organizationProvider, username, projectName, apiBaseUrl, commitUuid)
+      BaseCommandConfig(
+        projectToken,
+        apiToken,
+        organizationProvider,
+        username,
+        projectName,
+        apiBaseUrl,
+        commitUuid,
+        httpTimeout
+      )
 
     val commandConfig = Report(
       baseConfig = baseConfig,
@@ -48,7 +58,7 @@ class CodacyCoverageReporterSpec extends WordSpec with Matchers with EitherValue
   "run" should {
     "be successful" when {
       "using a project token to send coverage" in {
-        val result = runCoverageReport(projectToken, None, None, None, None, commitUuid)
+        val result = runCoverageReport(projectToken, None, None, None, None, commitUuid, httpTimeout = Some(10000))
 
         result shouldBe 'right
       }
@@ -57,7 +67,15 @@ class CodacyCoverageReporterSpec extends WordSpec with Matchers with EitherValue
         // empty projectToken so we skip project token
         // passing None will pick the token used for the codacy-coverage-reporter project
         val result =
-          runCoverageReport(None, apiToken, Option(OrganizationProvider.gh), username, projectName, commitUuid)
+          runCoverageReport(
+            None,
+            apiToken,
+            Option(OrganizationProvider.gh),
+            username,
+            projectName,
+            commitUuid,
+            httpTimeout = Some(10000)
+          )
 
         result shouldBe 'right
       }

--- a/src/main/scala/com/codacy/configuration/parser/ConfigurationParser.scala
+++ b/src/main/scala/com/codacy/configuration/parser/ConfigurationParser.scala
@@ -87,6 +87,8 @@ case class BaseCommandConfig(
     codacyApiBaseUrl: Option[String],
     @ValueDescription("your commitUUID")
     commitUUID: Option[String],
+    @ValueDescription("Sets a specified timeout value, in milliseconds, to be used when interacting with Codacy API")
+    httpTimeout: Option[Int] = None,
     @Name("s") @ValueDescription("skip if token isn't defined")
     skip: Int @@ Counter = Tag.of(0),
     @Hidden

--- a/src/main/scala/com/codacy/model/configuration/Configuration.scala
+++ b/src/main/scala/com/codacy/model/configuration/Configuration.scala
@@ -1,10 +1,9 @@
 package com.codacy.model.configuration
 
 import java.io.File
-
 import scala.util.matching.Regex
-
 import com.codacy.api.OrganizationProvider
+import com.codacy.api.client.RequestTimeout
 import com.codacy.parsers.CoverageParser
 import com.codacy.plugins.api.languages.{Language, Languages}
 
@@ -42,7 +41,8 @@ case class BaseConfig(
     authentication: AuthenticationConfig,
     codacyApiBaseUrl: String,
     commitUUID: Option[CommitUUID],
-    debug: Boolean
+    debug: Boolean,
+    timeoutOpt: Option[RequestTimeout]
 )
 
 sealed trait CommitUUID extends Any {

--- a/src/main/scala/com/codacy/rules/ConfigurationRules.scala
+++ b/src/main/scala/com/codacy/rules/ConfigurationRules.scala
@@ -1,6 +1,7 @@
 package com.codacy.rules
 
 import com.codacy.api.OrganizationProvider
+import com.codacy.api.client.RequestTimeout
 
 import java.io.File
 import java.net.URL
@@ -70,7 +71,8 @@ class ConfigurationRules(cmdConfig: CommandConfiguration, envVars: Map[String, S
         authConfig,
         baseConfig.codacyApiBaseUrl.getOrElse(getApiBaseUrl),
         commitUUID,
-        baseConfig.debugValue
+        baseConfig.debugValue,
+        timeoutOpt = baseConfig.httpTimeout.map(timeout => RequestTimeout(timeout, timeout))
       )
       validatedConfig <- validateBaseConfigUrl(baseConf)
     } yield {

--- a/src/test/scala/com/codacy/rules/ReportRulesSpec.scala
+++ b/src/test/scala/com/codacy/rules/ReportRulesSpec.scala
@@ -32,7 +32,7 @@ class ReportRulesSpec extends WordSpec with Matchers with PrivateMethodTester wi
 
   "codacyCoverage" should {
     val baseConfig =
-      BaseConfig(ProjectTokenAuthenticationConfig(projToken), apiBaseUrl, None, debug = false)
+      BaseConfig(ProjectTokenAuthenticationConfig(projToken), apiBaseUrl, None, debug = false, timeoutOpt = None)
 
     def assertCodacyCoverage(coverageServices: CoverageServices, coverageReports: List[String], success: Boolean) = {
       val reportRules = new ReportRules(coverageServices)


### PR DESCRIPTION
Also fixes the tests that were failing due to timeout.

Depends on: https://github.com/codacy/codacy-api-scala/pull/45