### PR TITLE
Add checksums as part of the GitHub release artifacts CY-4457

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,12 +277,11 @@ workflows:
           name: generate_checksums
           cmd: |
             cd ~/workdir/artifacts/
-            sha512sum codacy-coverage-reporter-linux > codacy-coverage-reporter-linux.SHA512SUM
-            sha512sum codacy-coverage-reporter-assembly.jar > codacy-coverage-reporter-assembly.jar.SHA512SUM
-            sha512sum codacy-coverage-reporter-darwin > codacy-coverage-reporter-darwin.SHA512SUM
-            sha512sum --check codacy-coverage-reporter-linux.SHA512SUM
-            sha512sum --check codacy-coverage-reporter-assembly.jar.SHA512SUM
-            sha512sum --check codacy-coverage-reporter-darwin.SHA512SUM
+            for binary_name in codacy-coverage-reporter-linux codacy-coverage-reporter-assembly.jar codacy-coverage-reporter-darwin
+            do
+              sha512sum "$binary_name" > "$binary_name.SHA512SUM"
+              sha512sum --check "$binary_name.SHA512SUM"
+            done
           persist_to_workspace: true
           requires:
             - package_artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,6 +273,19 @@ workflows:
           requires:
             - create_artifacts
             - create_artifacts_for_osx
+      - codacy/shell:
+          name: generate_checksums
+          cmd: |
+            cd ~/workdir/artifacts/
+            sha512sum codacy-coverage-reporter-linux > codacy-coverage-reporter-linux.SHA512SUM
+            sha512sum codacy-coverage-reporter-assembly.jar > codacy-coverage-reporter-assembly.jar.SHA512SUM
+            sha512sum codacy-coverage-reporter-darwin > codacy-coverage-reporter-darwin.SHA512SUM
+            sha512sum --check codacy-coverage-reporter-linux.SHA512SUM
+            sha512sum --check codacy-coverage-reporter-assembly.jar.SHA512SUM
+            sha512sum --check codacy-coverage-reporter-darwin.SHA512SUM
+          persist_to_workspace: true
+          requires:
+            - package_artifacts
       - it_coverage_script_macosx:
           requires:
             - package_artifacts
@@ -301,6 +314,7 @@ workflows:
             docker push codacy/$CIRCLE_PROJECT_REPONAME:$(cat .version)
           persist_to_workspace: true
           requires:
+            - generate_checksums
             - it_coverage_script_macosx
             - it_coverage_script_alpine
             - it_coverage_script_ubuntu_success
@@ -311,6 +325,7 @@ workflows:
                 - master
       - publish_circleci_artifacts:
           requires:
+            - generate_checksums
             - it_coverage_script_macosx
             - it_coverage_script_alpine
             - it_coverage_script_ubuntu_success
@@ -328,6 +343,7 @@ workflows:
               only:
                 - master
           requires:
+            - generate_checksums
             - it_coverage_script_macosx
             - it_coverage_script_alpine
             - it_coverage_script_ubuntu_success

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,20 +319,6 @@ workflows:
             branches:
               only:
                 - master
-      - codacy/publish_s3:
-          name: publish_bintray
-          path: bin/codacy-coverage-reporter
-          files: artifacts/codacy-coverage-reporter-linux artifacts/codacy-coverage-reporter-darwin artifacts/codacy-coverage-reporter-assembly.jar
-          filters:
-            branches:
-              only:
-                - master
-          context: CodacyAWS
-          requires:
-            - it_coverage_script_macosx
-            - it_coverage_script_alpine
-            - it_coverage_script_ubuntu_success
-            - it_coverage_script_ubuntu_failure
       - codacy/publish_ghr:
           name: publish_ghr
           path: ~/workdir/artifacts/
@@ -346,10 +332,21 @@ workflows:
             - it_coverage_script_alpine
             - it_coverage_script_ubuntu_success
             - it_coverage_script_ubuntu_failure
+      - codacy/publish_s3:
+          name: publish_s3
+          path: bin/codacy-coverage-reporter
+          files: artifacts/codacy-coverage-reporter-linux artifacts/codacy-coverage-reporter-darwin artifacts/codacy-coverage-reporter-assembly.jar
+          filters:
+            branches:
+              only:
+                - master
+          context: CodacyAWS
+          requires:
+            - publish_ghr
       - publish_dev:
           context: CodacyCircleCI
           requires:
-            - publish_ghr
+            - publish_s3
             - pack_and_validate_orb
           filters:
             branches:
@@ -358,7 +355,7 @@ workflows:
       - publish_prod:
           context: CodacyCircleCI
           requires:
-            - publish_ghr
+            - publish_s3
             - pack_and_validate_orb
           filters:
             branches:


### PR DESCRIPTION
Did some tests with some test/ branch and pre-releases and it they have been successfully published. This PR will start to store the SHA together with the release on GH, so on a follow up PR we can update the get.sh script to check the checksums against the binaries that come from artifacts.codacy.com.

![Screenshot 2021-08-11 at 17 09 20](https://user-images.githubusercontent.com/13315199/129065215-6a1d9d73-beb5-4ffe-b5c4-2e323878963f.png)
![Screenshot 2021-08-11 at 17 09 01](https://user-images.githubusercontent.com/13315199/129065301-2681995d-10cf-4814-ac0e-12000f80404d.png)
