### PR TITLE
feature: Only do checksum for versions >= 13.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ Usage: codacy-coverage-reporter report
  --> Succeeded!
 ```
 
+## Checksum
+
+Starting with version `13.0.0` the `get.sh` script does a checksum on the downloaded binary automatically.
+To override this behavior and skip the checksum of the binary you can:
+
+```bash
+export CODACY_REPORTER_SKIP_CHECKSUM=true
+```
+
 ## What is Codacy?
 
 [Codacy](https://www.codacy.com/) is an Automated Code Review Tool that monitors your technical debt, helps you improve your code quality, teaches best practices to your developers, and helps you save time in Code Reviews.

--- a/get.sh
+++ b/get.sh
@@ -93,16 +93,15 @@ checksum() {
   local file_name="$1"
   local checksum_url="$2"
   local major_version="$(echo "$CODACY_REPORTER_VERSION" | cut -d '.' -f 1)"
-  local minor_version="$(echo "$CODACY_REPORTER_VERSION" | cut -d '.' -f 2)"
 
   if [ "$CODACY_REPORTER_SKIP_CHECKSUM" = true ]; then
     log "$i" "Force skipping checksum on the binary."
-  elif [ "$major_version" -ge 12 ] && [ "$minor_version" -ge 4 ]; then
+  elif [ "$major_version" -ge 13 ]; then
     log "$i" "Checking checksum..."
     download_file "$checksum_url"
     sha512sum --check "$file_name.SHA512SUM"
   else
-    log "$i" "Checksum not available for versions prior to 12.4.0, consider updating your CODACY_REPORTER_VERSION"
+    log "$i" "Checksum not available for versions prior to 13.0.0, consider updating your CODACY_REPORTER_VERSION"
   fi
 }
 


### PR DESCRIPTION
CODACY_REPORTER_SKIP_CHECKSUM=true will skip the check
This is the de facto version that starts to check it,
it was 12.4.0 before for bootstraping purposes