### PR TITLE
fix: Use -c flag over --check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,7 +280,7 @@ workflows:
             for binary_name in codacy-coverage-reporter-linux codacy-coverage-reporter-assembly.jar codacy-coverage-reporter-darwin
             do
               sha512sum "$binary_name" > "$binary_name.SHA512SUM"
-              sha512sum --check "$binary_name.SHA512SUM"
+              sha512sum -c "$binary_name.SHA512SUM"
             done
           persist_to_workspace: true
           requires:

--- a/docs/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/alternative-ways-of-running-coverage-reporter.md
@@ -100,7 +100,7 @@ For example, run the commands below to download and validate the checksum for th
 
 ```bash
 curl -Ls -O https://github.com/codacy/codacy-coverage-reporter/releases/download/13.0.0/codacy-coverage-reporter-linux.SHA512SUM
-sha512sum --check codacy-coverage-reporter-linux.SHA512SUM
+sha512sum -c codacy-coverage-reporter-linux.SHA512SUM
 ```
 
 ## Building from source

--- a/get.sh
+++ b/get.sh
@@ -108,7 +108,7 @@ checksum() {
         fatal "Error: no method of validating checksum, please install 'sha512sum' or 'shasum'. You can skip this check by setting CODACY_REPORTER_SKIP_CHECKSUM=true"
     fi
 
-    $sha_check_command --check "$file_name.SHA512SUM"    
+    $sha_check_command -c "$file_name.SHA512SUM"
   else
     log "$i" "Checksum not available for versions prior to 13.0.0, consider updating your CODACY_REPORTER_VERSION"
   fi


### PR DESCRIPTION
It seems that some versions of sha512sum only support the -c mode
For the other checked versions, it does support both modes.

Example:

```
BusyBox v1.26.2 (2017-06-11 06:38:32 GMT) multi-call binary.

Usage: sha512sum [-c[sw]] [FILE]...

Print or check SHA512 checksums

	-c	Check sums against list in FILEs
	-s	Don't output anything, status code shows success
	-w	Warn about improperly formatted checksum lines
```

While others have

```
-c, --check          read SHA512 sums from the FILEs and check them
```