### PR TITLE
Add logs to help diagnosing when a SHA512 checksum verification fails

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -108,6 +108,10 @@ checksum() {
         fatal "Error: no method of validating checksum, please install 'sha512sum' or 'shasum'. You can skip this check by setting CODACY_REPORTER_SKIP_CHECKSUM=true"
     fi
 
+    log "$i" "Expected checksum"
+    cat "$file_name.SHA512SUM"
+    log "$i" "Actual checksum"
+    $sha_check_command "$file_name"
     $sha_check_command -c "$file_name.SHA512SUM"
   else
     log "$i" "Checksum not available for versions prior to 13.0.0, consider updating your CODACY_REPORTER_VERSION"


### PR DESCRIPTION
When I run the [get.sh][1] script on my Mac, the SHA512 checksum validation succeeds.

However, when the same script is run in a [GitHub action][2] I get the following logs:
```
2021-08-18T11:33:23.1599460Z  [0;36m--> [0;90mChecking checksum...[0m
2021-08-18T11:33:23.3368020Z #=#=#                                                                         
2021-08-18T11:33:23.3368950Z 
2021-08-18T11:33:23.4042110Z ######################################################################## 100.0%
2021-08-18T11:33:23.4043480Z ######################################################################## 100.0%
2021-08-18T11:33:23.9700550Z shasum: WARNING: 1 computed checksum did NOT match
2021-08-18T11:33:23.9702470Z codacy-coverage-reporter-darwin: FAILED
2021-08-18T11:33:23.9706780Z 
2021-08-18T11:33:23.9707960Z  [0;31m--> [0;90mFailed![0m
2021-08-18T11:33:23.9732850Z ##[error]Process completed with exit code 1.
```

Unfortunately, the `sha512sum` doesn't give enough information to understand why the checksum verification failed.

Adding a log of the expected checksum and the actual checksum will help diagnosing checksum verification issues.

[1]: https://raw.githubusercontent.com/codacy/codacy-coverage-reporter/master/get.sh
[2]: https://github.com/serilog-contrib/serilog-formatting-log4net/runs/3360548922