### PR TITLE
feature: Add logs for the SHA512 used during checksum verification

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -108,6 +108,10 @@ checksum() {
         fatal "Error: no method of validating checksum, please install 'sha512sum' or 'shasum'. You can skip this check by setting CODACY_REPORTER_SKIP_CHECKSUM=true"
     fi
 
+    log "$i" "Expected checksum"
+    cat "$file_name.SHA512SUM"
+    log "$i" "Actual checksum"
+    $sha_check_command "$file_name"
     $sha_check_command -c "$file_name.SHA512SUM"
   else
     log "$i" "Checksum not available for versions prior to 13.0.0, consider updating your CODACY_REPORTER_VERSION"


### PR DESCRIPTION
Adds the logs suggested at https://github.com/codacy/codacy-coverage-reporter/pull/345 thanks @0xced.

This will print the expected and actual checksum for both failure and success.