### PR TITLE
feature: Stop using pushd and popd for better compatibility

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -124,14 +124,15 @@ download() {
     local output_folder="$3"
     local output_filename="$4"
     local checksum_url="$5"
+    local original_folder="$(pwd)"
 
-    pushd "$output_folder"
+    cd "$output_folder"
 
     download_file "$url"
     checksum "$file_name" "$checksum_url"
     mv "$file_name" "$output_filename"
 
-    popd
+    cd "$original_folder"
 }
 
 download_reporter() {


### PR DESCRIPTION
As mention by @tobiasweibel at https://github.com/codacy/codacy-coverage-reporter/pull/335#discussion_r691186185, the pushd and popd are an enhancement of the POSIX standard in the bash shell.
There can be some cases where the shell don't have access to those commands.