### PR TITLE
doc: Include workaround for checksum issues in troubleshooting CY-4874

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,6 @@ Usage: codacy-coverage-reporter report
  --> Succeeded!
 ```
 
-## Checksum
-
-Starting with version `13.0.0` the `get.sh` script does a checksum on the downloaded binary automatically.
-To override this behavior and skip the checksum of the binary you can:
-
-```bash
-export CODACY_REPORTER_SKIP_CHECKSUM=true
-```
-
 ## What is Codacy?
 
 [Codacy](https://www.codacy.com/) is an Automated Code Review Tool that monitors your technical debt, helps you improve your code quality, teaches best practices to your developers, and helps you save time in Code Reviews.

--- a/docs/troubleshooting-common-issues.md
+++ b/docs/troubleshooting-common-issues.md
@@ -6,11 +6,11 @@ description: Instructions or workarounds to overcome common issues while using C
 
 The sections below provide instructions or workarounds to overcome common issues while using Codacy Coverage Reporter.
 
-## sha512sum: command not found while checking checksum {: id="checksum"}
+## Can't validate checksum {: id="checksum"}
 
-Starting on version [13.0.0](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.0.0) the `get.sh` script automatically validates the checksum of the downloaded Codacy Coverage Reporter binary. This requires having the `sha512sum` command on the operating system where you're running the script.
+Starting on version [13.0.0](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.0.0) the `get.sh` script automatically validates the checksum of the downloaded Codacy Coverage Reporter binary. This requires having either the `sha512sum` or `shasum` command on the operating system where you're running the script.
 
-If you're getting this error while uploading your coverage data to Codacy, install the correct version of `sha512sum` for the operating system that you're using.
+If you're getting this error while uploading your coverage data to Codacy, install the correct version of `sha512sum` or `shasum` for the operating system that you're using.
 
 You can also skip validating the checksum of the binary by defining the following environment variable, however, Codacy doesn't recommend this:
 

--- a/docs/troubleshooting-common-issues.md
+++ b/docs/troubleshooting-common-issues.md
@@ -6,6 +6,16 @@ description: Instructions or workarounds to overcome common issues while using C
 
 The sections below provide instructions or workarounds to overcome common issues while using Codacy Coverage Reporter.
 
+## Checksum
+
+Starting with [version 13.0.0](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.0.0) the `get.sh` script automatically validates the checksum of the downloaded Codacy Coverage Reporter binary.
+
+To override this behavior and skip validating the checksum of the binary define the following environment variable
+
+```bash
+export CODACY_REPORTER_SKIP_CHECKSUM=true
+```
+
 ## Can't guess any report due to no matching
 
 Codacy Coverage Reporter automatically searches for coverage reports matching the [file name conventions for supported formats](index.md#generating-coverage).

--- a/docs/troubleshooting-common-issues.md
+++ b/docs/troubleshooting-common-issues.md
@@ -6,11 +6,13 @@ description: Instructions or workarounds to overcome common issues while using C
 
 The sections below provide instructions or workarounds to overcome common issues while using Codacy Coverage Reporter.
 
-## Checksum
+## sha512sum: command not found while checking checksum {: id="checksum"}
 
-Starting with [version 13.0.0](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.0.0) the `get.sh` script automatically validates the checksum of the downloaded Codacy Coverage Reporter binary.
+Starting on version [13.0.0](https://github.com/codacy/codacy-coverage-reporter/releases/tag/13.0.0) the `get.sh` script automatically validates the checksum of the downloaded Codacy Coverage Reporter binary. This requires having the `sha512sum` command on the operating system where you're running the script.
 
-To override this behavior and skip validating the checksum of the binary define the following environment variable
+If you're getting this error while uploading your coverage data to Codacy, install the correct version of `sha512sum` for the operating system that you're using.
+
+You can also skip validating the checksum of the binary by defining the following environment variable, however, Codacy doesn't recommend this:
 
 ```bash
 export CODACY_REPORTER_SKIP_CHECKSUM=true

--- a/get.sh
+++ b/get.sh
@@ -105,7 +105,7 @@ checksum() {
     elif command -v shasum > /dev/null 2>&1; then
         sha_check_command="shasum -a 512"
     else
-        fatal "Error: no method of validating checksum, please install 'sha512sum' or 'shasum'. You can skip this check by setting CODACY_REPORTER_SKIP_CHECKSUM=true"
+        fatal "Error: can't validate checksum, please see https://docs.codacy.com/coverage-reporter/troubleshooting-common-issues/#checksum"
     fi
 
     log "$i" "Expected checksum"


### PR DESCRIPTION
Following the [feedback](https://codacy.atlassian.net/browse/CY-4874?focusedCommentId=47679) from @dan-codacy and other reports from users who have had issues with the checksum calculation, we should make the workaround for disabling the checksum calculation more visible, directly in the existing [troubleshooting page](https://docs.codacy.com/coverage-reporter/troubleshooting-common-issues/).