### PR TITLE
feature: Troubleshooting for coverage missing in Codacy UI DOCS-222

### DIFF
--- a/docs/troubleshooting-common-issues.md
+++ b/docs/troubleshooting-common-issues.md
@@ -73,3 +73,10 @@ If you're using PHPUnit version 5 or above to generate your coverage report, you
 To change the output format replace the flag `--coverage-xml <dir>` with `--coverage-clover <file>` when executing `phpunit`.
 
 See [PHPUnit command-line documentation](https://phpunit.readthedocs.io/en/latest/textui.html) for more information.
+
+## No coverage data is visible on the Codacy UI
+
+If the Codacy Coverage Reporter correctly uploaded your coverage report but the coverage data doesn't show up on the Codacy UI, please validate the following:
+
+-   Make sure that the file paths included in your coverage reports are relative to the root directory of your repository. For example, `src/index.js`.
+-   Verify that the Codacy Coverage Reporter is uploading the coverage data for the [correct commit in the correct branch](index.md#commit-detection).


### PR DESCRIPTION
Adds a small troubleshooting section for the scenario where the Codacy Coverage Reporter successfully uploads the coverage data but it doesn't become visible on the Codacy UI. The cause can either be a mismatch in the file paths included in the coverage reports or a wrong commit UUID being reported.

Fixes https://github.com/codacy/codacy-coverage-reporter/issues/234.