### PR TITLE
doc: Codacy only displays coverage after the second commit DOCS-307

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -178,13 +178,13 @@ After having coverage reports set up for your repository, you must use Codacy Co
 
         See [alternative ways of running Codacy Coverage Reporter](alternative-ways-of-running-coverage-reporter.md) for other ways of running Codacy Coverage Reporter, such as by installing the binary manually or using a GitHub Action or CircleCI Orb.
 
-1.  Validate that the uploaded coverage data was successfully read by Codacy. To do this, check that Codacy displays the coverage information on your next commit or pull request, either as a positive, negative, or no variation (repesented by `=`) of the coverage percentage:
-
-    ![Coverage data displayed on Codacy](images/coverage-codacy-ui.png)
-
-    Follow [these troubleshooting steps](troubleshooting-common-issues.md#no-coverage-visible) if Codacy doesn't display the coverage data for your commit or pull request (repesented by `-`).
-
 1.  Optionally, [add a Codacy badge](https://docs.codacy.com/repositories/badges/) to the README of your repository to display the current code coverage.
+
+To validate that the coverage setup is complete, **wait until your repository has at least two new commits** and check that Codacy displays the coverage information on the last commit or in subsequent pull requests, either as a positive, negative, or no variation (repesented by `=`) of the coverage percentage:
+
+![Coverage data displayed on Codacy](images/coverage-codacy-ui.png)
+
+Follow [these troubleshooting steps](troubleshooting-common-issues.md#no-coverage-visible) if Codacy doesn't display the coverage data for your commit or pull request (repesented by `-`).
 
 ### Uploading multiple coverage reports for the same language {: id="multiple-reports"}
 


### PR DESCRIPTION
Clarifies that users must wait until the second commit to start seeing the coverage information on the Codacy UI.

Preview of the page:

https://github.com/codacy/codacy-coverage-reporter/blob/b1279df30c9416d920fab7552f71bf000421db57/docs/index.md#2-uploading-coverage-data-to-codacy--iduploading-coverage