### PR TITLE
doc: Update description for the flag --language

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Usage: codacy-coverage-reporter report
   --commit-uuid  <your commitUUID>
   --http-timeout  <Sets a specified timeout value, in milliseconds, to be used when interacting with Codacy API>
   --skip | -s  <skip if token isn't defined>
-  --language | -l  <your project language>
+  --language | -l  <language associated with your coverage report>
   --coverage-reports | -r  <your project coverage file name>
   --partial  <if the report is partial>
   --prefix  <the project path prefix>

--- a/src/main/scala/com/codacy/configuration/parser/ConfigurationParser.scala
+++ b/src/main/scala/com/codacy/configuration/parser/ConfigurationParser.scala
@@ -54,7 +54,7 @@ case class Final(
 case class Report(
     @Recurse
     baseConfig: BaseCommandConfig,
-    @Name("l") @ValueDescription("your project language")
+    @Name("l") @ValueDescription("language associated with your coverage report")
     language: Option[String],
     @Hidden @Name("f")
     forceLanguage: Int @@ Counter = Tag.of(0),


### PR DESCRIPTION
The flag `--language` forces associating a language to the coverage report being uploaded, not to the repository, as seen here:

https://github.com/codacy/codacy-coverage-reporter/blob/doc/update-language-flag/src/main/scala/com/codacy/rules/ReportRules.scala#L175-L197

This pull request applies a change similar to [the one from codacy-coverage-reporter-action](https://github.com/codacy/codacy-coverage-reporter-action/pull/57#pullrequestreview-855781715) to this repository.