### PR TITLE
doc: Include AWS CodeBuild commit SHA detection CY-5787

### DIFF
--- a/docs/troubleshooting-common-issues.md
+++ b/docs/troubleshooting-common-issues.md
@@ -18,6 +18,7 @@ If the Codacy Coverage Reporter correctly uploaded your coverage report but the 
 The Codacy Coverage Reporter automatically detects the commit SHA hash to associate with the coverage data from the following CI/CD platforms:
 
 -   Appveyor
+-   AWS CodeBuild
 -   Azure Pipelines
 -   Bitrise
 -   Buildkite


### PR DESCRIPTION
Reflects the update from https://github.com/codacy/codacy-coverage-reporter/pull/362 on the docs.