### PR TITLE
doc: Fix find command syntax

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -201,7 +201,7 @@ You can also upload all your reports dynamically using the command `find`. For e
 
 ```bash
 bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
-    -l Java $(find **/jacoco*.xml -printf '-r %p ')
+    -l Java $(find -name 'jacoco*.xml' -printf '-r %p ')
 ```
 
 !!! note


### PR DESCRIPTION
The previous syntax would only find reports called `jacoco*.xml` inside the **first level of subdirectories**.

The updated command ensures that any file `jacoco*.xml` will be found not only across all levels of subdirectories but on the root of the repository as well.