### PR TITLE
fix: Use the http-timeout for the read-timeout only CY-6106

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Usage: codacy-coverage-reporter report
   --project-name | -p  <your project name>
   --codacy-api-base-url  <the base URL for the Codacy API>
   --commit-uuid  <your commitUUID>
-  --http-timeout  <Sets a specified timeout value, in milliseconds, to be used when interacting with Codacy API>
+  --http-timeout  <Sets a specified read timeout value, in milliseconds, to be used when interacting with Codacy API>
   --skip | -s  <skip if token isn't defined>
   --language | -l  <language associated with your coverage report>
   --coverage-reports | -r  <your project coverage file name>

--- a/src/main/scala/com/codacy/configuration/parser/ConfigurationParser.scala
+++ b/src/main/scala/com/codacy/configuration/parser/ConfigurationParser.scala
@@ -87,7 +87,9 @@ case class BaseCommandConfig(
     codacyApiBaseUrl: Option[String],
     @ValueDescription("your commitUUID")
     commitUUID: Option[String],
-    @ValueDescription("Sets a specified timeout value, in milliseconds, to be used when interacting with Codacy API")
+    @ValueDescription(
+      "Sets a specified read timeout value, in milliseconds, to be used when interacting with Codacy API"
+    )
     httpTimeout: Int = 10000,
     @Name("s") @ValueDescription("skip if token isn't defined")
     skip: Int @@ Counter = Tag.of(0),

--- a/src/main/scala/com/codacy/rules/ConfigurationRules.scala
+++ b/src/main/scala/com/codacy/rules/ConfigurationRules.scala
@@ -72,7 +72,7 @@ class ConfigurationRules(cmdConfig: CommandConfiguration, envVars: Map[String, S
         baseConfig.codacyApiBaseUrl.getOrElse(getApiBaseUrl),
         commitUUID,
         baseConfig.debugValue,
-        timeout = RequestTimeout(baseConfig.httpTimeout, baseConfig.httpTimeout)
+        timeout = RequestTimeout(connTimeoutMs = 1000, readTimeoutMs = baseConfig.httpTimeout)
       )
       validatedConfig <- validateBaseConfigUrl(baseConf)
     } yield {

--- a/src/test/scala/com/codacy/rules/ReportRulesSpec.scala
+++ b/src/test/scala/com/codacy/rules/ReportRulesSpec.scala
@@ -37,7 +37,7 @@ class ReportRulesSpec extends WordSpec with Matchers with PrivateMethodTester wi
         apiBaseUrl,
         None,
         debug = false,
-        timeout = RequestTimeout(10000, 10000)
+        timeout = RequestTimeout(1000, 10000)
       )
 
     def assertCodacyCoverage(
@@ -88,7 +88,7 @@ class ReportRulesSpec extends WordSpec with Matchers with PrivateMethodTester wi
           any[String],
           any[CoverageReport],
           anyBoolean,
-          Some(RequestTimeout(10000, 10000))
+          Some(RequestTimeout(1000, 10000))
         ) returns FailedResponse("Failed to send report")
 
         assertCodacyCoverage(coverageServices, List("src/test/resources/dotcover-example.xml"), success = false)
@@ -103,7 +103,7 @@ class ReportRulesSpec extends WordSpec with Matchers with PrivateMethodTester wi
         any[String],
         any[CoverageReport],
         anyBoolean,
-        Some(RequestTimeout(10000, 10000))
+        Some(RequestTimeout(1000, 10000))
       ) returns SuccessfulResponse(RequestSuccess("Success"))
 
       assertCodacyCoverage(coverageServices, List("src/test/resources/dotcover-example.xml"), success = true)


### PR DESCRIPTION
The intent is for the http-timeout only increase the readTimeout which was the initial intention.

For the connection timeout, changing it to 1000, as it is the default from the lib, so it goes back to the behaviour it had before https://github.com/codacy/codacy-coverage-reporter/pull/380 regarding connection timeout