### PR TITLE
doc: Use ordered list to clarify how to use --partial and final

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -213,7 +213,12 @@ bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
 ```
 
 !!! note
-    Alternatively, you can upload each report separately with the flag `--partial` and notify Codacy with the `final` command after uploading all reports. For example:
+    Alternatively, you can:
+    
+    1.   Upload each report separately with the flag `--partial`
+    1.   Notify Codacy with the `final` command after uploading all reports
+    
+    For example:
 
     ```bash
     bash <(curl -Ls https://coverage.codacy.com/get.sh) report \


### PR DESCRIPTION
This change tries to make it more explicit that users reporting multiple coverage reports must use the `final` command after uploading all reports.