### PR TITLE
doc: Improve recommendation for fixing MalformedInputException DOCS-349

### DIFF
--- a/docs/troubleshooting-common-issues.md
+++ b/docs/troubleshooting-common-issues.md
@@ -92,9 +92,9 @@ There are some ways you can solve this:
 
 ## MalformedInputException while parsing report
 
-If you get a `java.nio.charset.MalformedInputException` when running the Codacy Coverage Reporter it means that the coverage report includes an unsupported character, perhaps on one of your source code file names.
+If you get a `java.nio.charset.MalformedInputException` when running the Codacy Coverage Reporter it means that the coverage report includes a character that is not encoded in UTF-8. The invalid character can belong to the file name of one of your source code files, or even a class or method name.
 
-For maximum compatibility of your coverage reports with the Codacy Coverage Reporter, make sure that your coverage reports use UTF-8 encoding or remove any special characters from the reports.
+For maximum compatibility of your coverage reports with the Codacy Coverage Reporter, make sure that your coverage reports use UTF-8 encoding and that they only include UTF-8 characters.
 
 ## SubstrateSegfaultHandler caught signal 11
 


### PR DESCRIPTION
Improves the troubleshooting for the error `java.nio.charset.MalformedInputException` when uploading a coverage report.

According to this [Stack Overflow thread](https://stackoverflow.com/questions/26268132/all-inclusive-charset-to-avoid-java-nio-charset-malformedinputexception-input) and by looking at our coverage report parser implementation we're using the default character encoding UTF-8 while reading the coverage reports. This had also [been validated](https://codacy.atlassian.net/browse/CY-3801?focusedCommentId=45707) by @lolgab. So, any character outside of this charset will throw the exception.

As a suggestion, would it be possible to make the Codacy Coverage Reporter more robust to this type of errors - either by reading/parsing the report correctly or by outputting a helpful error message?

Fixes https://github.com/codacy/docs/issues/1007.