### PR TITLE
doc: Add explicit starting path to find command

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -209,7 +209,7 @@ You can also upload all your reports dynamically using the command `find`. For e
 
 ```bash
 bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
-    -l Java $(find -name 'jacoco*.xml' -printf '-r %p ')
+    -l Java $(find . -name 'jacoco*.xml' -printf '-r %p ')
 ```
 
 !!! note


### PR DESCRIPTION
After [receiving feedback from a user](https://app.intercom.com/a/apps/a53cb793563c5f92959598bf8b22fe8f01ec3199/inbox/inbox/conversation/1644200179523) we realized that it's more explicit to include the optional path in the `find` command.