### PR TITLE
doc: Add guidelines for contacting Support DOCS-394

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -152,15 +152,15 @@ After having coverage reports set up for your repository, you must use Codacy Co
         ```
 
     -   **If you're setting up and automating coverage for multiple repositories**, [obtain an account API Token](../codacy-api/api-tokens/#account-api-tokens) and set the following environment variables:
-    
+
         -   **CODACY_API_TOKEN:** Your account API token.
 
         -   **CODACY_ORGANIZATION_PROVIDER:** Git provider hosting the repository.
-        
+
             Must be one of `gh`, `ghe`, `gl`, `gle`, `bb`, or `bbe` to specify GitHub, GitHub Enterprise, GitLab, GitLab Enterprise, Bitbucket, or Bitbucket Enterprise, respectively.
 
         -   **CODACY_USERNAME:** Name of your organization on the Git provider, or your username on the Git provider if you're using a personal organization.
-        
+
         -   **CODACY_PROJECT_NAME:** Name of the repository for which you're uploading the coverage information.
 
         ```bash
@@ -220,10 +220,10 @@ bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
 
 !!! note
     Alternatively, you can:
-    
+
     1.   Upload each report separately with the flag `--partial`
     1.   Notify Codacy with the `final` command after uploading all reports
-    
+
     For example:
 
     ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -310,6 +310,7 @@ To validate that the coverage setup is complete:
 
         -   URL of your repository on Codacy
         -   Your CI configuration files and the name of your CI platform
+        -   Full console output of your CI when running the Codacy Coverage Reporter
+        -   Branch name and commit UUID corresponding to the CI output
         -   Test coverage report that you're uploading to Codacy
-        -   Branch name, commit UUID, and full console output of the Codacy Coverage Reporter
         -   Any other relevant information or screenshots of your setup

--- a/docs/index.md
+++ b/docs/index.md
@@ -302,5 +302,14 @@ To validate that the coverage setup is complete:
 1.  Check that Codacy displays the coverage information for the latest commits and pull requests:
 
     ![Coverage data displayed on Codacy](images/coverage-codacy-ui.png)
-    
-    **If Codacy doesn't display the coverage data** for the latest commits or pull requests (represented by `-`), [follow these troubleshooting instructions](troubleshooting-common-issues.md#no-coverage-visible).
+
+1.  **If Codacy doesn't display the coverage data** for the latest commits or pull requests (represented by `-`), please [follow these troubleshooting instructions](troubleshooting-common-issues.md#no-coverage-visible) or contact us for more help:
+
+    !!! note "Opening a Support ticket"
+        If you need more help setting up coverage on your repository please contact us at <mailto:support@codacy.com> including the following information:
+
+        -   URL of your repository on Codacy
+        -   Your CI configuration files and the name of your CI platform
+        -   Test coverage report that you're uploading to Codacy
+        -   Branch name, commit UUID, and full console output of the Codacy Coverage Reporter
+        -   Any other relevant information or screenshots of your setup

--- a/docs/index.md
+++ b/docs/index.md
@@ -309,8 +309,8 @@ To validate that the coverage setup is complete:
         If you need more help setting up coverage on your repository please contact us at <mailto:support@codacy.com> including the following information:
 
         -   URL of your repository on Codacy
-        -   Your CI configuration files and the name of your CI platform
-        -   Full console output of your CI when running the Codacy Coverage Reporter
-        -   Branch name and commit UUID corresponding to the CI output
+        -   Your CI/CD configuration files and the name of your CI/CD platform
+        -   Full console output of your CI/CD when running the Codacy Coverage Reporter
+        -   Branch name and commit UUID corresponding to the CI/CD output
         -   Test coverage report that you're uploading to Codacy
         -   Any other relevant information or screenshots of your setup


### PR DESCRIPTION
Adds a checklist of the information necessary to troubleshoot the coverage setup and that users should include when contacting Support to make the process more efficient.

### :eyes: Live preview
https://feature-update-codacy-coverage-repo--docs-codacy.netlify.app/coverage-reporter/#validating-coverage