### PR TITLE
doc: Refactor coverage documentation

### DIFF
--- a/docs/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/alternative-ways-of-running-coverage-reporter.md
@@ -1,5 +1,5 @@
 ---
-description: There are alternative ways of running or installing Codacy Coverage Reporter, such as running a Docker image, downloading a binary for your operating system, or building the binary from source.
+description: There are alternative ways of running or installing Codacy Coverage Reporter, such as running a Docker image, using a GitHub Action or CircleCI orb, downloading a binary for your operating system, or building the binary from source.
 ---
 
 # Alternative ways of running Coverage Reporter

--- a/docs/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/alternative-ways-of-running-coverage-reporter.md
@@ -4,6 +4,10 @@ description: There are alternative ways of running or installing Codacy Coverage
 
 # Alternative ways of running Coverage Reporter
 
+The following sections list the alternative ways of running or installing Codacy Coverage Reporter.
+
+## Bash script (recommended) {: id="bash-script"}
+
 The recommended way to run Codacy Coverage Reporter is using a self-contained script that automatically downloads and runs the most recent version of Codacy Coverage Reporter:
 
 -   On Ubuntu, run:
@@ -35,8 +39,6 @@ export CODACY_REPORTER_VERSION=<version>
     ```bash
     export CODACY_REPORTER_SKIP_CHECKSUM=true
     ```
-
-The sections below provide details on alternative ways to run or install Codacy Coverage Reporter.
 
 ## Docker
 

--- a/docs/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/alternative-ways-of-running-coverage-reporter.md
@@ -8,7 +8,7 @@ The following sections list the alternative ways of running or installing Codacy
 
 ## Bash script (recommended) {: id="bash-script"}
 
-The recommended way to run Codacy Coverage Reporter is using a self-contained script that automatically downloads and runs the most recent version of Codacy Coverage Reporter:
+The recommended way to run the Codacy Coverage Reporter is by using the [self-contained bash script `get.sh`](https://github.com/codacy/codacy-coverage-reporter/blob/master/get.sh) that automatically downloads and runs the most recent version of the Codacy Coverage Reporter:
 
 -   On Ubuntu, run:
 
@@ -22,6 +22,13 @@ The recommended way to run Codacy Coverage Reporter is using a self-contained sc
     wget -qO - https://coverage.codacy.com/get.sh | sh
     ```
 
+!!! note
+    Starting on version `13.0.0` the script automatically validates the checksum of the downloaded binary. To skip the checksum validation, define the following environment variable:
+
+    ```bash
+    export CODACY_REPORTER_SKIP_CHECKSUM=true
+    ```
+
 The self-contained script can cache the binary. To avoid downloading the binary every time that the script runs, add one of the following directories to your CI cached folders:
 
 -   `$HOME/.cache/codacy` on Linux
@@ -32,13 +39,6 @@ To use a specific version of the Codacy Coverage Reporter, set the following env
 ```bash
 export CODACY_REPORTER_VERSION=<version>
 ```
-
-!!! note
-    Starting on version `13.0.0` the script automatically validates the checksum of the downloaded binary. To skip the checksum validation, define the following environment variable:
-
-    ```bash
-    export CODACY_REPORTER_SKIP_CHECKSUM=true
-    ```
 
 ## Docker
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -140,7 +140,14 @@ As a last resort, you can also send the coverage data directly by calling one of
 
 ## 2. Uploading coverage data to Codacy {: id="uploading-coverage"}
 
-After having coverage reports set up for your repository, you must use Codacy Coverage Reporter to convert the reports to smaller JSON files and upload these files to Codacy. The recommended way to do this is using a CI/CD platform that automatically runs tests, generates coverage, and uses Codacy Coverage Reporter to upload the coverage report information for every push to your repository.
+After having coverage reports set up for your repository, you must use the Codacy Coverage Reporter to convert the reports to smaller JSON files and upload these files to Codacy.
+
+The recommended way to do this is by using a CI/CD platform that automatically runs tests, generates coverage, and uses the Codacy Coverage Reporter to upload the coverage report information for every push to your repository.
+
+!!! note "Alternative ways of running the Codacy Coverage Reporter"
+    The instructions on this page assume that you'll run a self-contained bash script `get.sh` to automatically download and run the most recent version of the Codacy Coverage Reporter.
+    
+    However, there are [alternative ways to run the Codacy Coverage Reporter](alternative-ways-of-running-coverage-reporter.md), such as by installing the binary manually or by using Docker, a GitHub Action, or a CircleCI Orb.
 
 1.  Set up an API token to allow Codacy Coverage Reporter to authenticate on Codacy:
     {: id="authenticate"}
@@ -189,10 +196,8 @@ After having coverage reports set up for your repository, you must use Codacy Co
 
     Check the console output to validate that the Codacy Coverage Reporter **detected the correct commit UUID** and **successfully uploaded** the coverage data to Codacy. If you need help, [check the troubleshooting page](troubleshooting-common-issues.md) for solutions to the most common setup issues.
 
-    !!! tip
-        The self-contained script `get.sh` automatically downloads and runs the most recent version of Codacy Coverage Reporter. See [alternative ways of running Codacy Coverage Reporter](alternative-ways-of-running-coverage-reporter.md) for other ways of running Codacy Coverage Reporter, such as by installing the binary manually or using a GitHub Action or CircleCI Orb.
-
-        Be sure to also check the [instructions for more advanced scenarios](uploading-coverage-in-advanced-scenarios.md) while uploading the coverage data to Codacy.
+    !!! note
+        Be sure to also check the [instructions for more advanced scenarios](uploading-coverage-in-advanced-scenarios.md) while uploading the coverage data to Codacy, such as when you need to upload multiple coverage reports.
 
 1.  Make sure that Codacy received the coverage data successfully for the **correct commit UUID and branch**. On Codacy, open your **Repository Settings**, tab **Coverage**, and observe the list of recent coverage reports in the section **Test your integration**:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -197,7 +197,7 @@ The recommended way to do this is by using a CI/CD platform that automatically r
     Check the console output to validate that the Codacy Coverage Reporter **detected the correct commit UUID** and **successfully uploaded** the coverage data to Codacy. If you need help, [check the troubleshooting page](troubleshooting-common-issues.md) for solutions to the most common setup issues.
 
     !!! note
-        Be sure to also check the [instructions for more advanced scenarios](uploading-coverage-in-advanced-scenarios.md) while uploading the coverage data to Codacy, such as when you need to upload multiple coverage reports.
+        Be sure to also check the [instructions for more advanced scenarios](uploading-coverage-in-advanced-scenarios.md) while uploading the coverage data to Codacy, such as when running parallel tests, using monorepos, or testing source code in multiple or unsupported languages.
 
 1.  Make sure that Codacy received the coverage data successfully for the **correct commit UUID and branch**. On Codacy, open your **Repository Settings**, tab **Coverage**, and observe the list of recent coverage reports in the section **Test your integration**:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,7 +116,7 @@ The following table contains example coverage tools that generate reports in for
 </tbody>
 </table>
 
-### Submitting coverage from unsupported report formats
+### Handling unsupported report formats
 
 If you're generating a report format that Codacy doesn't support yet, [contribute with a parser implementation](https://github.com/codacy/codacy-coverage-reporter/tree/master/coverage-parser/src/main/scala/com/codacy/parsers/implementation) yourself or use one of the community projects below to generate coverage reports in a supported format:
 
@@ -202,9 +202,14 @@ After having coverage reports set up for your repository, you must use Codacy Co
 
 ### Uploading multiple coverage reports for the same language {: id="multiple-reports"}
 
-If your test suite is split in different modules or runs in parallel, you must upload multiple coverage reports for the same language.
+If your test suite is split in different modules or runs in parallel, you must upload multiple coverage reports for the same language either at once or in sequence.
 
-To do this, specify multiple reports by repeating the flag `-r`. For example:
+!!! tip
+    Alternatively, it might also be possible to merge the coverage reports before uploading them to Codacy, since most coverage tools support merging or aggregating the coverage data. For example, use the [merge mojo for JaCoCo](http://www.eclemma.org/jacoco/trunk/doc/merge-mojo.html).
+
+#### Uploading multiple reports at once {: id="multiple-reports-once"}
+
+Upload multiple partial coverage reports with a single command by specifying each report with the flag `-r`. For example:
 
 ```bash
 bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
@@ -218,26 +223,25 @@ bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
     -l Java $(find . -name 'jacoco*.xml' -printf '-r %p ')
 ```
 
-!!! note
-    Alternatively, you can:
+#### Uploading multiple reports in sequence {: id="multiple-reports-sequence"}
 
-    1.   Upload each report separately with the flag `--partial`
-    1.   Notify Codacy with the `final` command after uploading all reports
+Upload multiple partial coverage reports in sequence:
 
-    For example:
+1.  Upload each report separately with the flag `--partial`.
 
-    ```bash
-    bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
-        --partial -l Java -r report1.xml
-    bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
-        --partial -l Java -r report2.xml
-    bash <(curl -Ls https://coverage.codacy.com/get.sh) final
-    ```
+    If you're sending reports for a language with the flag `--partial`, you must use the flag in all reports for that language to ensure the correct calculation of the coverage.
 
-    If you're sending reports for a language with the flag `--partial`, you should use the flag in all reports for that language to ensure the correct calculation of the coverage.
+1.  Notify Codacy with the `final` command after uploading all reports.
 
-!!! tip
-    It might also be possible to merge the reports before uploading them to Codacy, since most coverage tools support merge/aggregation. For example, <http://www.eclemma.org/jacoco/trunk/doc/merge-mojo.html>.
+For example:
+
+```bash
+bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
+    --partial -l Java -r report1.xml
+bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
+    --partial -l Java -r report2.xml
+bash <(curl -Ls https://coverage.codacy.com/get.sh) final
+```
 
 ### Uploading the same coverage report for multiple languages {: id="multiple-languages"}
 
@@ -252,7 +256,7 @@ bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
     -l TypeScript -r report.xml
 ```
 
-### Submitting coverage for Golang
+### Uploading coverage for Golang {: id="golang"}
 
 Codacy can't automatically detect Golang coverage report files because they don't have specific file names.
 
@@ -263,7 +267,7 @@ bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
     --force-coverage-parser go -r <coverage report file name>
 ```
 
-### Submitting coverage for unsupported languages
+### Uploading coverage for unsupported languages {: id="unsupported-languages"}
 
 If your language isn't in the list of supported languages, you can still send coverage to Codacy.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -192,93 +192,13 @@ After having coverage reports set up for your repository, you must use Codacy Co
     !!! tip
         The self-contained script `get.sh` automatically downloads and runs the most recent version of Codacy Coverage Reporter. See [alternative ways of running Codacy Coverage Reporter](alternative-ways-of-running-coverage-reporter.md) for other ways of running Codacy Coverage Reporter, such as by installing the binary manually or using a GitHub Action or CircleCI Orb.
 
-        Be sure to also check the sections below for more advanced functionality while uploading the coverage data to Codacy.
+        Be sure to also check the [instructions for more advanced scenarios](uploading-coverage-in-advanced-scenarios.md) while uploading the coverage data to Codacy.
 
 1.  Make sure that Codacy received the coverage data successfully for the **correct commit UUID and branch**. On Codacy, open your **Repository Settings**, tab **Coverage**, and observe the list of recent coverage reports in the section **Test your integration**:
 
     ![Testing the coverage integration](images/coverage-test-integration.png)
 
     If you make adjustments to your setup and upload new coverage data, click the button **Test integration** to refresh the table.
-
-### Uploading multiple coverage reports for the same language {: id="multiple-reports"}
-
-If your test suite is split in different modules or runs in parallel, you must upload multiple coverage reports for the same language either at once or in sequence.
-
-!!! tip
-    Alternatively, it might also be possible to merge the coverage reports before uploading them to Codacy, since most coverage tools support merging or aggregating the coverage data. For example, use the [merge mojo for JaCoCo](http://www.eclemma.org/jacoco/trunk/doc/merge-mojo.html).
-
-#### Uploading multiple reports at once {: id="multiple-reports-once"}
-
-Upload multiple partial coverage reports with a single command by specifying each report with the flag `-r`. For example:
-
-```bash
-bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
-    -l Java -r report1.xml -r report2.xml -r report3.xml
-```
-
-You can also upload all your reports dynamically using the command `find`. For example:
-
-```bash
-bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
-    -l Java $(find . -name 'jacoco*.xml' -printf '-r %p ')
-```
-
-#### Uploading multiple reports in sequence {: id="multiple-reports-sequence"}
-
-Upload multiple partial coverage reports in sequence:
-
-1.  Upload each report separately with the flag `--partial`.
-
-    If you're sending reports for a language with the flag `--partial`, you must use the flag in all reports for that language to ensure the correct calculation of the coverage.
-
-1.  Notify Codacy with the `final` command after uploading all reports.
-
-For example:
-
-```bash
-bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
-    --partial -l Java -r report1.xml
-bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
-    --partial -l Java -r report2.xml
-bash <(curl -Ls https://coverage.codacy.com/get.sh) final
-```
-
-### Uploading the same coverage report for multiple languages {: id="multiple-languages"}
-
-If your test suite generates a single coverage report for more than one language, you must upload the same coverage report for each language.
-
-To do this, upload the same report multiple times, specifying each different language with the flag `-l`. For example:
-
-```bash
-bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
-    -l Javascript -r report.xml
-bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
-    -l TypeScript -r report.xml
-```
-
-### Uploading coverage for Golang {: id="golang"}
-
-Codacy can't automatically detect Golang coverage report files because they don't have specific file names.
-
-If you're uploading a Golang coverage report, you must also specify the report type:
-
-```bash
-bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
-    --force-coverage-parser go -r <coverage report file name>
-```
-
-### Uploading coverage for unsupported languages {: id="unsupported-languages"}
-
-If your language isn't in the list of supported languages, you can still send coverage to Codacy.
-
-To do this, provide the correct language with the flag `-l`, together with `--force-language`. For example:
-
-```bash
-bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
-  -l Kotlin --force-language -r <coverage report file name>
-```
-
-See the [list of languages](https://github.com/codacy/codacy-plugins-api/blob/master/src/main/scala/com/codacy/plugins/api/languages/Language.scala#L43) that you can specify using the flag `-l`.
 
 ## 3. Validating that the coverage setup is complete {: id="validating-coverage"}
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -116,7 +116,7 @@ The following table contains example coverage tools that generate reports in for
 </tbody>
 </table>
 
-### Handling unsupported report formats
+### Handling unsupported languages
 
 If you're generating a report format that Codacy doesn't support yet, [contribute with a parser implementation](https://github.com/codacy/codacy-coverage-reporter/tree/master/coverage-parser/src/main/scala/com/codacy/parsers/implementation) yourself or use one of the community projects below to generate coverage reports in a supported format:
 
@@ -132,6 +132,9 @@ If you're generating a report format that Codacy doesn't support yet, [contribut
 -   [dariodf/lcov_ex](https://github.com/dariodf/lcov_ex): generate LCOV reports for Elixir projects
 -   [chrisgit/sfdx-plugins_apex_coverage_report](https://github.com/chrisgit/sfdx-plugins_apex_coverage_report): generate LCOV or Cobertura reports from [Apex](https://help.salesforce.com/articleView?id=sf.code_apex_dev_guide_tools.htm&type=5) code coverage data
 -   [danielpalme/ReportGenerator](https://github.com/danielpalme/ReportGenerator): convert between different report formats
+
+!!! important
+    Make sure that you [specify the language](uploading-coverage-in-advanced-scenarios.md#unsupported-languages) when uploading coverage for an unsupported language.
 
 As a last resort, you can also send the coverage data directly by calling one of the following Codacy API endpoints:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -145,9 +145,9 @@ After having coverage reports set up for your repository, you must use the Codac
 The recommended way to do this is by using a CI/CD platform that automatically runs tests, generates coverage, and uses the Codacy Coverage Reporter to upload the coverage report information for every push to your repository.
 
 !!! note "Alternative ways of running the Codacy Coverage Reporter"
-    The instructions on this page assume that you'll run a self-contained bash script `get.sh` to automatically download and run the most recent version of the Codacy Coverage Reporter.
-    
-    However, there are [alternative ways to run the Codacy Coverage Reporter](alternative-ways-of-running-coverage-reporter.md), such as by installing the binary manually or by using Docker, a GitHub Action, or a CircleCI Orb.
+    Codacy makes available [alternative ways to run the Codacy Coverage Reporter](alternative-ways-of-running-coverage-reporter.md), such as by installing the binary manually or by using Docker, a GitHub Action, or a CircleCI Orb.
+
+    However, the instructions on this page assume that you'll run the recommended [self-contained bash script `get.sh`](alternative-ways-of-running-coverage-reporter.md#bash-script) to automatically download and run the most recent version of the Codacy Coverage Reporter.    
 
 1.  Set up an API token to allow Codacy Coverage Reporter to authenticate on Codacy:
     {: id="authenticate"}

--- a/docs/index.md
+++ b/docs/index.md
@@ -140,7 +140,7 @@ As a last resort, you can also send the coverage data directly by calling one of
 
 ## 2. Uploading coverage data to Codacy {: id="uploading-coverage"}
 
-After having coverage reports set up for your repository, you must use the Codacy Coverage Reporter to convert the reports to smaller JSON files and upload these files to Codacy.
+After having coverage reports set up for your repository, you must use the Codacy Coverage Reporter to upload them to Codacy.
 
 The recommended way to do this is by using a CI/CD platform that automatically runs tests, generates coverage, and uses the Codacy Coverage Reporter to upload the coverage report information for every push to your repository.
 

--- a/docs/uploading-coverage-in-advanced-scenarios.md
+++ b/docs/uploading-coverage-in-advanced-scenarios.md
@@ -1,0 +1,87 @@
+---
+description: Instructions on how to use the Codacy Coverage Reporter to upload coverage data in more advanced scenarios.
+---
+
+# Uploading coverage in advanced scenarios
+
+The following sections include instructions on how to use the Codacy Coverage Reporter to upload coverage data in more advanced scenarios.
+
+## Uploading multiple coverage reports for the same language {: id="multiple-reports"}
+
+If your test suite is split in different modules or runs in parallel, you must upload multiple coverage reports for the same language either at once or in sequence.
+
+!!! tip
+    Alternatively, it might also be possible to merge the coverage reports before uploading them to Codacy, since most coverage tools support merging or aggregating the coverage data. For example, use the [merge mojo for JaCoCo](http://www.eclemma.org/jacoco/trunk/doc/merge-mojo.html).
+
+### Uploading all reports at once {: id="multiple-reports-once"}
+
+Upload multiple partial coverage reports with a single command by specifying each report with the flag `-r`. For example:
+
+```bash
+bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
+    -l Java -r report1.xml -r report2.xml -r report3.xml
+```
+
+You can also upload all your reports dynamically using the command `find`. For example:
+
+```bash
+bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
+    -l Java $(find . -name 'jacoco*.xml' -printf '-r %p ')
+```
+
+### Uploading reports in sequence {: id="multiple-reports-sequence"}
+
+Upload multiple partial coverage reports in sequence:
+
+1.  Upload each report separately with the flag `--partial`.
+
+    If you're sending reports for a language with the flag `--partial`, you must use the flag in all reports for that language to ensure the correct calculation of the coverage.
+
+1.  Notify Codacy with the `final` command after uploading all reports.
+
+For example:
+
+```bash
+bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
+    --partial -l Java -r report1.xml
+bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
+    --partial -l Java -r report2.xml
+bash <(curl -Ls https://coverage.codacy.com/get.sh) final
+```
+
+## Uploading the same coverage report for multiple languages {: id="multiple-languages"}
+
+If your test suite generates a single coverage report for more than one language, you must upload the same coverage report for each language.
+
+To do this, upload the same report multiple times, specifying each different language with the flag `-l`. For example:
+
+```bash
+bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
+    -l Javascript -r report.xml
+bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
+    -l TypeScript -r report.xml
+```
+
+## Uploading coverage for Golang {: id="golang"}
+
+Codacy can't automatically detect Golang coverage report files because they don't have specific file names.
+
+If you're uploading a Golang coverage report, you must also specify the report type:
+
+```bash
+bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
+    --force-coverage-parser go -r <coverage report file name>
+```
+
+## Uploading coverage for unsupported languages {: id="unsupported-languages"}
+
+If your language isn't in the list of supported languages, you can still send coverage to Codacy.
+
+To do this, provide the correct language with the flag `-l`, together with `--force-language`. For example:
+
+```bash
+bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
+  -l Kotlin --force-language -r <coverage report file name>
+```
+
+See the [list of languages](https://github.com/codacy/codacy-plugins-api/blob/master/src/main/scala/com/codacy/plugins/api/languages/Language.scala#L43) that you can specify using the flag `-l`.

--- a/docs/uploading-coverage-in-advanced-scenarios.md
+++ b/docs/uploading-coverage-in-advanced-scenarios.md
@@ -75,7 +75,7 @@ bash <(curl -Ls https://coverage.codacy.com/get.sh) report \
 
 ## Uploading coverage for unsupported languages {: id="unsupported-languages"}
 
-If your language isn't in the list of supported languages, you can still send coverage to Codacy.
+If your language isn't in the [list of supported languages](index.md#generating-coverage), you can still send coverage to Codacy.
 
 To do this, provide the correct language with the flag `-l`, together with `--force-language`. For example:
 

--- a/docs/uploading-coverage-in-advanced-scenarios.md
+++ b/docs/uploading-coverage-in-advanced-scenarios.md
@@ -1,5 +1,5 @@
 ---
-description: Instructions on how to use the Codacy Coverage Reporter to upload coverage data in more advanced scenarios.
+description: Instructions on how to use the Codacy Coverage Reporter to upload coverage data in advanced scenarios such as when running parallel tests, using monorepos, or testing source code in multiple or unsupported languages.
 ---
 
 # Uploading coverage in advanced scenarios

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,4 +25,5 @@ markdown_extensions:
 nav:
   - "index.md"
   - "alternative-ways-of-running-coverage-reporter.md"
+  - "uploading-coverage-in-advanced-scenarios.md"
   - "troubleshooting-common-issues.md"


### PR DESCRIPTION
The [main page with instructions for setting up coverage](https://docs.codacy.com/coverage-reporter/) is getting too big, making it hard to follow through the complete sequence of instructions.

This pull request:

- Moves the instructions for more advanced scenarios to a dedicated page
- Tweaks a few references and admonitions so that they appear in the sequence that makes the most sense while users are configuring their setup

These improvements will give way to more detailed troubleshooting instructions for the most common coverage setup failure scenarios (see [CY-6263](https://codacy.atlassian.net/browse/CY-6263)).