### PR TITLE
docs: Change commit UUID to commit SHA-1 hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Usage: codacy-coverage-reporter report
   --username | -u  <the project owner name>
   --project-name | -p  <your project name>
   --codacy-api-base-url  <the base URL for the Codacy API>
-  --commit-uuid  <your commitUUID>
+  --commit-uuid  <your commit SHA-1 hash>
   --http-timeout  <Sets a specified read timeout value, in milliseconds, to be used when interacting with Codacy API. By default, the value is 10 seconds>
   --skip | -s  <skip if token isn't defined>
   --sleep-time <Sets a specified time, in milliseconds, to be used when waiting between retries. By default, the value is 10 seconds>

--- a/src/main/scala/com/codacy/configuration/parser/ConfigurationParser.scala
+++ b/src/main/scala/com/codacy/configuration/parser/ConfigurationParser.scala
@@ -85,7 +85,7 @@ case class BaseCommandConfig(
     projectName: Option[String],
     @ValueDescription("the base URL for the Codacy API")
     codacyApiBaseUrl: Option[String],
-    @ValueDescription("your commitUUID")
+    @ValueDescription("your commit SHA-1 hash")
     commitUUID: Option[String],
     @ValueDescription(
       "Sets a specified read timeout value, in milliseconds, to be used when interacting with Codacy API. By default, the value is 10 seconds"

--- a/src/main/scala/com/codacy/model/configuration/Configuration.scala
+++ b/src/main/scala/com/codacy/model/configuration/Configuration.scala
@@ -66,7 +66,7 @@ object CommitUUID {
     if (isValid(commitUUID)) {
       Right(CommitUUIDImpl(commitUUID))
     } else {
-      Left("Commit UUID is not valid. Make sure the commit SHA consists of 40 hexadecimal characters.")
+      Left("Commit SHA-1 hash isn't valid. Make sure it consists of 40 hexadecimal characters.")
     }
 
   /** Commit UUID class that guarantees it contains a valid commit SHA, since it can only be instantiated via

--- a/src/main/scala/com/codacy/rules/commituuid/CommitUUIDProvider.scala
+++ b/src/main/scala/com/codacy/rules/commituuid/CommitUUIDProvider.scala
@@ -18,10 +18,10 @@ trait CommitUUIDProvider {
   val name: String
 
   /** Default error message */
-  protected val commitNotFoundMessage = s"Can't find $name commit UUID in the environment."
+  protected val commitNotFoundMessage = s"Can't find $name commit SHA-1 hash in the environment."
 
   protected val commitNotValidMessage =
-    "Commit UUID is not valid. Make sure the commit SHA consists of 40 hexadecimal characters."
+    "Commit SHA-1 hash isn't valid. Make sure it consists of 40 hexadecimal characters."
 
   /** Parses `environmentVariable` as a [[CommitUUID]], validates it and returns it, as a [[Right]].
     *
@@ -93,7 +93,7 @@ object CommitUUIDProvider extends LogSupport {
     getFromEnvironment(environment) match {
       case Left(msg) =>
         logger.info(msg)
-        logger.info("Trying to get commit UUID from local Git directory")
+        logger.info("Trying to get commit SHA-1 hash from local Git directory")
         getLatestFromGit()
       case uuid => uuid
     }
@@ -107,10 +107,10 @@ object CommitUUIDProvider extends LogSupport {
     val currentPath = new File(System.getProperty("user.dir"))
     new GitClient(currentPath).latestCommitInfo match {
       case Failure(e) =>
-        Left("Commit UUID not provided and could not retrieve it from local Git directory")
+        Left("Commit SHA-1 hash not provided and could not retrieve it from local Git directory")
       case Success(CommitInfo(uuid, authorName, authorEmail, date)) =>
         val info =
-          s"""Commit UUID not provided, using latest commit of local Git directory:
+          s"""Commit SHA-1 hash not provided, using latest commit of local Git directory:
             |$uuid $authorName <$authorEmail> $date""".stripMargin
 
         logger.info(info)
@@ -134,7 +134,7 @@ object CommitUUIDProvider extends LogSupport {
     }
 
     validUUID
-      .toRight("Can't find or validate commit UUID from any supported CI/CD provider.")
+      .toRight("Can't find or validate commit SHA-1 hash from any supported CI/CD provider.")
       .flatMap(identity)
   }
 }


### PR DESCRIPTION
@mrfyda and I reached the conclusion that the Codacy Coverage Reporter is using the internal Codacy lingo "commit UUID" when referring to what's known by most developers as the "commit SHA-1 hash".

This is a proposal to change the way we refer to the SHA-1 hash in the CLI output of the Codacy Coverage Reporter.