### PR TITLE
doc: Fix rowspan on coverage troubleshooting table

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -330,7 +330,7 @@ Follow these instructions to validate that your coverage setup is working correc
         </td>
     </tr>
     <tr>
-        <td rowspan="3">
+        <td rowspan="4">
             <p style="color: #2562EA;"><strong>Pending</strong></p>
             <p>Codacy is waiting to receive more coverage data before reporting the coverage for a commit.</p>
         </td>


### PR DESCRIPTION
I forgot to update the rowspan value while adding a new table row in https://github.com/codacy/codacy-coverage-reporter/pull/414.