### PR TITLE
feature: warn user when multiple languages are detected IO-52

### DIFF
--- a/src/main/scala/com/codacy/rules/ReportRules.scala
+++ b/src/main/scala/com/codacy/rules/ReportRules.scala
@@ -43,7 +43,7 @@ class ReportRules(coverageServices: => CoverageServices) extends LogSupport {
               transform(coverageResult.report)(finalConfig)
           }
           _ <- storeReport(report, file)
-          language <- guessReportLanguage(finalConfig.languageOpt, report)
+          language <- guessReportLanguage(finalConfig.languageOpt, report, file.getAbsolutePath)
           success <- sendReport(report, language, finalConfig, commitUUID, file)
         } yield {
           success
@@ -194,16 +194,31 @@ class ReportRules(coverageServices: => CoverageServices) extends LogSupport {
     */
   private[rules] def guessReportLanguage(
       languageOpt: Option[String],
-      report: CoverageReport
+      report: CoverageReport,
+      reportFilePath: String
   ): Either[String, String] = {
     languageOpt match {
       case Some(l) => Right(l)
       case None =>
-        report.fileReports.flatMap(file => Languages.forPath(file.filename)).headOption match {
+        val reportLanguages = getReportLanguages(report).distinct
+        reportLanguages.headOption match {
           case None => Left("Can't guess the report language")
-          case Some(value) => Right(value.name)
+          case Some(language) =>
+            if (reportLanguages.size > 1) {
+              logger.warn(s"""
+                   |Multiple languages detected in $reportFilePath (${reportLanguages.mkString(",")}).
+                   |  This run will report coverage for the $language language.
+                   |  To make sure you are uploading this report for all languages,
+                   |  check https://docs.codacy.com/coverage-reporter/uploading-coverage-in-advanced-scenarios/#multiple-languages
+                   |  for further details.""".stripMargin)
+            }
+            Right(language)
         }
     }
+  }
+
+  private[rules] def getReportLanguages(report: CoverageReport): Seq[String] = {
+    report.fileReports.flatMap(file => Languages.forPath(file.filename).map(_.name)).distinct
   }
 
   /**

--- a/src/main/scala/com/codacy/rules/ReportRules.scala
+++ b/src/main/scala/com/codacy/rules/ReportRules.scala
@@ -205,12 +205,13 @@ class ReportRules(coverageServices: => CoverageServices) extends LogSupport {
           case None => Left("Can't guess the report language")
           case Some(language) =>
             if (reportLanguages.size > 1) {
-              logger.warn(s"""
+              logger.warn(
+                s"""
                    |Multiple languages detected in $reportFilePath (${reportLanguages.mkString(",")}).
-                   |  This run will report coverage for the $language language.
-                   |  To make sure you are uploading this report for all languages,
-                   |  check https://docs.codacy.com/coverage-reporter/uploading-coverage-in-advanced-scenarios/#multiple-languages
-                   |  for further details.""".stripMargin)
+                   |  This run will only upload coverage for the $language language.
+                   |  To make sure that you upload coverage for all languages in the report,
+                   |  see https://docs.codacy.com/coverage-reporter/uploading-coverage-in-advanced-scenarios/#multiple-languages""".stripMargin
+              )
             }
             Right(language)
         }

--- a/src/test/scala/com/codacy/rules/ReportRulesSpec.scala
+++ b/src/test/scala/com/codacy/rules/ReportRulesSpec.scala
@@ -130,21 +130,30 @@ class ReportRulesSpec extends WordSpec with Matchers with PrivateMethodTester wi
 
   "guessReportLanguage" should {
     "provide the available language" in {
-      val langEither = components.reportRules.guessReportLanguage(conf.language, noLanguageReport)
+      val langEither = components.reportRules.guessReportLanguage(
+        languageOpt = conf.language,
+        report = noLanguageReport,
+        reportFilePath = "I/am/a/file.extension"
+      )
 
       langEither should be('right)
       langEither.right.value should be(conf.language.get)
     }
 
     "provide the Scala language from report" in {
-      val langEither = components.reportRules.guessReportLanguage(None, coverageReport)
+      val langEither = components.reportRules
+        .guessReportLanguage(languageOpt = None, report = coverageReport, reportFilePath = "I/am/a/file.extension")
 
       langEither should be('right)
       langEither.right.value should be(Languages.Scala.name)
     }
 
     "not provide the language from an empty report" in {
-      components.reportRules.guessReportLanguage(None, noLanguageReport) should be('left)
+      components.reportRules.guessReportLanguage(
+        languageOpt = None,
+        report = noLanguageReport,
+        reportFilePath = "I/am/a/file.extension"
+      ) should be('left)
     }
   }
 


### PR DESCRIPTION
### Scope

For each coverage report file, the coverage reporter will:
- look through the files that are referenced in the report and extract its language by looking at file extensions
- if there are many languages, it will pick the first one and report all coverage as that language

This is problematic since it is not visible to the users (they just call our script) and it is possible that a report contains results for multiple languages.  

If you set the `-l` parameter it will override this behavior, but you must send the same report multiple times, one per language.

### This PR

When we make the decision to pick a specific language, we now output:
- that it is happening, 
- in what file, 
- what other languages were detected, and 
- a link to the relevant documentation.