### PR TITLE
Update alternative run examples to be interactive

### DIFF
--- a/docs/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/alternative-ways-of-running-coverage-reporter.md
@@ -19,9 +19,7 @@ The recommended way to run the Codacy Coverage Reporter is by using the [self-co
 -   On Alpine Linux, run:
 
     ```sh
-    wget -q https://coverage.codacy.com/get.sh
-    sh get.sh report -r <coverage report file name>
-    rm get.sh
+    wget -qO - https://coverage.codacy.com/get.sh | sh -s -- report -r <coverage report file name>
     ```
 
 !!! note

--- a/docs/alternative-ways-of-running-coverage-reporter.md
+++ b/docs/alternative-ways-of-running-coverage-reporter.md
@@ -13,13 +13,15 @@ The recommended way to run the Codacy Coverage Reporter is by using the [self-co
 -   On Ubuntu, run:
 
     ```bash
-    bash <(curl -Ls https://coverage.codacy.com/get.sh)
+    bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r <coverage report file name>
     ```
 
 -   On Alpine Linux, run:
 
     ```sh
-    wget -qO - https://coverage.codacy.com/get.sh | sh
+    wget -q https://coverage.codacy.com/get.sh
+    sh get.sh report -r <coverage report file name>
+    rm get.sh
     ```
 
 !!! note


### PR DESCRIPTION
The [current ("Bash") examples](https://docs.codacy.com/coverage-reporter/alternative-ways-of-running-coverage-reporter/#bash-script) don't show how to run the script interactively, so that users can configure the reporter using the CLI options.

I mainly want to document how to run the reporter on Alpine (without installing `bash`). I haven't tested that my update works on Ubuntu, but assuming this works it would be the same as the [regular run method](https://docs.codacy.com/coverage-reporter/#uploading-coverage)...which means we can possibly remove it entirely?