### PR TITLE
doc: Add IDs for each coverage error status table row CY-6365

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -244,7 +244,7 @@ Follow these instructions to validate that your coverage setup is working correc
     </thead>
     <tbody>
     <tr>
-        <td rowspan="2">
+        <td rowspan="2" id="status-commit-not-found">
             <p style="color: #EF5454;"><strong>Commit not found</strong></p>
             <p>Codacy doesn't have information about the commit associated with the coverage data.</p>
         </td>
@@ -265,7 +265,7 @@ Follow these instructions to validate that your coverage setup is working correc
         </td>
     </tr>
     <tr>
-       <td rowspan="2">
+       <td rowspan="2" id="status-branch-not-enabled">
             <p style="color: #EF5454;"><strong>Branch not enabled</strong></p>
             <p>The commit associated with the coverage data doesn't belong to any branch that Codacy is analyzing.</p>
         </td>
@@ -286,7 +286,7 @@ Follow these instructions to validate that your coverage setup is working correc
         </td>
     </tr>
     <tr>
-        <td rowspan="5">
+        <td rowspan="5" id="status-commit-not-analyzed">
             <p style="color: #EF5454;"><strong>Commit not analyzed</strong></p>
             <p>Due to technical limitations, Codacy only reports coverage for a commit after successfully completing the static code analysis of that commit.</p>
         </td>
@@ -330,7 +330,7 @@ Follow these instructions to validate that your coverage setup is working correc
         </td>
     </tr>
     <tr>
-        <td rowspan="4">
+        <td rowspan="4" id="status-pending">
             <p style="color: #2562EA;"><strong>Pending</strong></p>
             <p>Codacy is waiting to receive more coverage data before reporting the coverage for a commit.</p>
         </td>


### PR DESCRIPTION
Adds IDs to the coverage status troubleshooting table so that we can create direct anchor links for each error status.