### PR TITLE
doc: Add @codacy/techwriters as /docs/ CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @codacy/toss
+/docs/ @codacy/techwriters


### PR DESCRIPTION
Adds the GitHub group @codacy/techwriters as CODEOWNERS of the `/docs/` directory.