### PR TITLE
doc: Suggest rebasing branch to fix missing coverage variation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -214,8 +214,11 @@ Because of this, to ensure that all code coverage metrics are available on Codac
 !!! note "Example"
     The example below shows that after pushing a commit that correctly sets up coverage on the main branch:
 
-    -   Codacy will report coverage metrics for all subsequent commits and pull requests relative to the main branch
-    -   Codacy won't report coverage metrics for commits and pull requests that are relative to older branches where the coverage setup wasn't performed yet
+    -   Codacy will report coverage metrics for all subsequent commits and pull requests relative to the main branch.
+
+    -   Codacy won't report coverage metrics for commits and pull requests that are relative to older branches where the coverage setup wasn't performed yet.
+
+        To solve this issue, you can rebase the old feature branch to update the common ancestor commit to one that already has coverage data.
 
     ![Setting up coverage on the main branch](images/coverage-validate.png)
 


### PR DESCRIPTION
If the common ancestor commit between a pull request and the target branch is missing coverage data, developers can rebase the branch to ensure that Codacy can calculate both coverage metrics.