### PR TITLE
bump: Self hosted version to 13.13.0 for SH release 11.0.0

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -176,7 +176,7 @@ is_self_hosted_instance() {
 os_name=$(uname)
 
 # This version should be one that matches the latest self hosted release.
-SELF_HOSTED_CODACY_REPORTER_VERSION="13.12.3"
+SELF_HOSTED_CODACY_REPORTER_VERSION="13.13.0"
 
 # Find the latest version in case is not specified
 if [ -z "$CODACY_REPORTER_VERSION" ] || [ "$CODACY_REPORTER_VERSION" = "latest" ]; then


### PR DESCRIPTION
Bumping coverage-reporter version to the latest version: `13.13.0`.