### PR TITLE
fix: Use `BigInt` instead of `Long` in `toIntOrMaxValue` TS-549

### DIFF
--- a/coverage-parser/src/main/scala/com/codacy/parsers/implementation/CoberturaParser.scala
+++ b/coverage-parser/src/main/scala/com/codacy/parsers/implementation/CoberturaParser.scala
@@ -59,8 +59,9 @@ object CoberturaParser extends CoverageParser with XmlReportParser {
     } {
       val key = (line \@ "number").toInt
       val value = (line \@ "hits").toIntOrMaxValue
+      val sum = map.get(key).getOrElse(0) + BigInt(value)
 
-      map(key) = map.get(key).getOrElse(0) + value
+      map(key) = sum.toIntOrMaxValue
     }
 
     CoverageFileReport(sourceFilename, fileHit, map.toMap)

--- a/coverage-parser/src/main/scala/com/codacy/parsers/util/MathUtils.scala
+++ b/coverage-parser/src/main/scala/com/codacy/parsers/util/MathUtils.scala
@@ -7,12 +7,13 @@ object MathUtils {
   }
 
   implicit class ParseIntOps(val s: String) extends AnyVal {
+    def toIntOrMaxValue: Int = BigInt(s).toIntOrMaxValue
+  }
 
-    def toIntOrMaxValue: Int = {
-      val bigInt = BigInt(s)
+  implicit class BigIntOps(val bigInt: BigInt) extends AnyVal {
 
+    def toIntOrMaxValue: Int =
       if (bigInt.isValidInt) bigInt.toInt
       else Int.MaxValue
-    }
   }
 }

--- a/coverage-parser/src/main/scala/com/codacy/parsers/util/MathUtils.scala
+++ b/coverage-parser/src/main/scala/com/codacy/parsers/util/MathUtils.scala
@@ -9,9 +9,9 @@ object MathUtils {
   implicit class ParseIntOps(val s: String) extends AnyVal {
 
     def toIntOrMaxValue: Int = {
-      val long = s.toLong
-      if (long > Int.MaxValue) Int.MaxValue
-      else long.toInt
+      val bigInt = s.map(_.asDigit: BigInt)
+      if (bigInt > Int.MaxValue) Int.MaxValue
+      else bigInt.toInt
     }
   }
 }

--- a/coverage-parser/src/main/scala/com/codacy/parsers/util/MathUtils.scala
+++ b/coverage-parser/src/main/scala/com/codacy/parsers/util/MathUtils.scala
@@ -9,9 +9,10 @@ object MathUtils {
   implicit class ParseIntOps(val s: String) extends AnyVal {
 
     def toIntOrMaxValue: Int = {
-      val bigInt = s.map(_.asDigit: BigInt)
-      if (bigInt > Int.MaxValue) Int.MaxValue
-      else bigInt.toInt
+      val bigInt = BigInt(s)
+
+      if (bigInt.isValidInt) bigInt.toInt
+      else Int.MaxValue
     }
   }
 }

--- a/coverage-parser/src/test/resources/test_cobertura.xml
+++ b/coverage-parser/src/test/resources/test_cobertura.xml
@@ -13,6 +13,7 @@
                         <line number="7" hits="0"/>
                         <line number="8" hits="1"/>
                         <line number="8" hits="2"/>
+                        <line number="9" hits="9999999999999999"/>
                     </lines>
                 </class>
                 <class line-rate="0.87" name="TestSourceFile" filename="coverage-parser/src/test/resources/TestSourceFile.scala">

--- a/coverage-parser/src/test/scala/com/codacy/parsers/CoberturaParserTest.scala
+++ b/coverage-parser/src/test/scala/com/codacy/parsers/CoberturaParserTest.scala
@@ -36,7 +36,7 @@ class CoberturaParserTest extends WordSpec with BeforeAndAfterAll with Matchers 
           CoverageFileReport(
             "coverage-parser/src/test/resources/TestSourceFile.scala",
             87,
-            Map(5 -> 1, 10 -> 1, 6 -> 2, 9 -> 1, 3 -> 0, 4 -> 1, 7 -> 1, 8 -> 3)
+            Map(5 -> 1, 10 -> 1, 6 -> 2, 9 -> Int.MaxValue, 3 -> 0, 4 -> 1, 7 -> 1, 8 -> 3)
           )
         )
       )

--- a/coverage-parser/src/test/scala/com/codacy/parsers/CoverageParserFactoryTest.scala
+++ b/coverage-parser/src/test/scala/com/codacy/parsers/CoverageParserFactoryTest.scala
@@ -21,7 +21,7 @@ class CoverageParserFactoryTest extends WordSpec with BeforeAndAfterAll with Mat
           CoverageFileReport(
             "coverage-parser/src/test/resources/TestSourceFile.scala",
             87,
-            Map(5 -> 1, 10 -> 1, 6 -> 2, 9 -> 1, 3 -> 0, 4 -> 1, 7 -> 1, 8 -> 3)
+            Map(5 -> 1, 10 -> 1, 6 -> 2, 9 -> 1, 3 -> 0, 4 -> 1, 7 -> 1, 8 -> 3, 9 -> Int.MaxValue)
           )
         )
       )


### PR DESCRIPTION
Author: @jasonm23