### PR TITLE
breaking: Update to Scala `3.3.3`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ references:
 
 commands:
   run_coverage_reporting:
-    description: "Runs the coverage reporting using the stub-server as API"
+    description: "Runs the coverage reporting using the mock-server as API"
     parameters:
       executor:
         type: string
@@ -125,8 +125,8 @@ jobs:
           name: wait for mockserver
           command: wget --retry-connrefused --method=PUT http://localhost:1080/mockserver/status
       - run:
-          name: configure stub server
-          command: wget --method=PUT --body-data="$(cat integration-tests/stub-server-config.json)" http://localhost:1080/mockserver/expectation
+          name: configure mock server
+          command: wget --method=PUT --body-data="$(cat integration-tests/mock-server-config.json)" http://localhost:1080/mockserver/expectation
       - run_coverage_reporting:
           executor: sh
           error_code: 0
@@ -148,7 +148,7 @@ jobs:
           name: wait for mockserver
           command: timeout 60 bash -c 'while [[ "$(curl -X PUT -o /dev/null -w ''%{http_code}'' localhost:1080/mockserver/status)" != "200" ]]; do sleep 2; done' || false
       - run:
-          name: configure stub server
+          name: configure mock server
           command: curl -v -X PUT localhost:1080/mockserver/expectation -d "$(cat << parameters.config_path >>)"
       - run_coverage_reporting:
           executor: bash
@@ -174,7 +174,7 @@ jobs:
             echo "Start and provision the mockserver"
             nohup mockserver -logLevel INFO -serverPort 1080 &
             gtimeout 60 bash -c 'while [[ "$(curl -X PUT -o /dev/null -w ''%{http_code}'' localhost:1080/mockserver/status)" != "200" ]]; do sleep 2; done' || false
-            curl -X PUT -d "$(cat integration-tests/stub-server-config.json)" http://localhost:1080/mockserver/expectation
+            curl -X PUT -d "$(cat integration-tests/mock-server-config.json)" http://localhost:1080/mockserver/expectation
 
             echo "Run the test"
             set +e
@@ -288,13 +288,13 @@ workflows:
       - it_coverage_script_ubuntu:
           name: it_coverage_script_ubuntu_success
           error_code: 0
-          config_path: integration-tests/stub-server-config.json
+          config_path: integration-tests/mock-server-config.json
           requires:
             - package_artifacts
       - it_coverage_script_ubuntu:
           name: it_coverage_script_ubuntu_failure
           error_code: 1
-          config_path: integration-tests/stub-server-error-config.json
+          config_path: integration-tests/mock-server-error-config.json
           requires:
             - package_artifacts
       - codacy/shell:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ references:
 
 commands:
   run_coverage_reporting:
-    description: "Runs the coverage reporting using the mock-server as API"
+    description: "Runs the coverage reporting using the stub-server as API"
     parameters:
       executor:
         type: string
@@ -125,8 +125,8 @@ jobs:
           name: wait for mockserver
           command: wget --retry-connrefused --method=PUT http://localhost:1080/mockserver/status
       - run:
-          name: configure mock server
-          command: wget --method=PUT --body-data="$(cat integration-tests/mock-server-config.json)" http://localhost:1080/mockserver/expectation
+          name: configure stub server
+          command: wget --method=PUT --body-data="$(cat integration-tests/stub-server-config.json)" http://localhost:1080/mockserver/expectation
       - run_coverage_reporting:
           executor: sh
           error_code: 0
@@ -148,7 +148,7 @@ jobs:
           name: wait for mockserver
           command: timeout 60 bash -c 'while [[ "$(curl -X PUT -o /dev/null -w ''%{http_code}'' localhost:1080/mockserver/status)" != "200" ]]; do sleep 2; done' || false
       - run:
-          name: configure mock server
+          name: configure stub server
           command: curl -v -X PUT localhost:1080/mockserver/expectation -d "$(cat << parameters.config_path >>)"
       - run_coverage_reporting:
           executor: bash
@@ -174,7 +174,7 @@ jobs:
             echo "Start and provision the mockserver"
             nohup mockserver -logLevel INFO -serverPort 1080 &
             gtimeout 60 bash -c 'while [[ "$(curl -X PUT -o /dev/null -w ''%{http_code}'' localhost:1080/mockserver/status)" != "200" ]]; do sleep 2; done' || false
-            curl -X PUT -d "$(cat integration-tests/mock-server-config.json)" http://localhost:1080/mockserver/expectation
+            curl -X PUT -d "$(cat integration-tests/stub-server-config.json)" http://localhost:1080/mockserver/expectation
 
             echo "Run the test"
             set +e
@@ -288,13 +288,13 @@ workflows:
       - it_coverage_script_ubuntu:
           name: it_coverage_script_ubuntu_success
           error_code: 0
-          config_path: integration-tests/mock-server-config.json
+          config_path: integration-tests/stub-server-config.json
           requires:
             - package_artifacts
       - it_coverage_script_ubuntu:
           name: it_coverage_script_ubuntu_failure
           error_code: 1
-          config_path: integration-tests/mock-server-error-config.json
+          config_path: integration-tests/stub-server-error-config.json
           requires:
             - package_artifacts
       - codacy/shell:

--- a/api-scala/src/main/scala/com/codacy/api/CoverageReport.scala
+++ b/api-scala/src/main/scala/com/codacy/api/CoverageReport.scala
@@ -7,7 +7,7 @@ case class CoverageFileReport(filename: String, coverage: Map[Int, Int])
 case class CoverageReport(fileReports: Seq[CoverageFileReport])
 
 object CoverageReport {
-  implicit val mapWrites: Writes[Map[Int, Int]] = Writes[Map[Int, Int]] { map: Map[Int, Int] =>
+  implicit val mapWrites: Writes[Map[Int, Int]] = Writes[Map[Int, Int]] { (map: Map[Int, Int]) =>
     JsObject(map.map {
       case (key, value) => (key.toString, JsNumber(value))
     })

--- a/api-scala/src/main/scala/com/codacy/api/helpers/vcs/GitClient.scala
+++ b/api-scala/src/main/scala/com/codacy/api/helpers/vcs/GitClient.scala
@@ -7,7 +7,7 @@ import org.eclipse.jgit.lib.{Repository, RepositoryBuilder}
 import org.eclipse.jgit.revwalk.RevWalk
 import org.eclipse.jgit.treewalk.TreeWalk
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 case class CommitInfo(uuid: String, authorName: String, authorEmail: String, date: Date)
@@ -53,9 +53,10 @@ class GitClient(workDirectory: File) {
 
       val result: Seq[String] =
         if (treeWalk.next) {
-          Stream
+          Iterator
             .continually(treeWalk.getPathString)
             .takeWhile(_ => treeWalk.next)
+            .toSeq
         } else Seq.empty
 
       result

--- a/api-scala/src/main/scala/com/codacy/api/helpers/vcs/GitClient.scala
+++ b/api-scala/src/main/scala/com/codacy/api/helpers/vcs/GitClient.scala
@@ -53,10 +53,9 @@ class GitClient(workDirectory: File) {
 
       val result: Seq[String] =
         if (treeWalk.next) {
-          Iterator
+          LazyList
             .continually(treeWalk.getPathString)
             .takeWhile(_ => treeWalk.next)
-            .toSeq
         } else Seq.empty
 
       result

--- a/api-scala/src/test/scala/com/codacy/api/GitClientTest.scala
+++ b/api-scala/src/test/scala/com/codacy/api/GitClientTest.scala
@@ -2,10 +2,11 @@ package com.codacy.api
 
 import com.codacy.api.helpers.vcs.GitClient
 import java.nio.file.Paths
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.OptionValues._
 
-class GitClientTest extends FlatSpec with Matchers {
+class GitClientTest extends AnyFlatSpec with Matchers {
 
   "GitClient" should "latestCommitUuid" in {
 
@@ -15,7 +16,7 @@ class GitClientTest extends FlatSpec with Matchers {
 
     latest shouldNot be(None)
 
-    latest.value shouldNot be('empty)
+    latest.value shouldNot be(Symbol("empty"))
   }
 
 }

--- a/coverage-parser/src/main/scala/com/codacy/parsers/implementation/CloverParser.scala
+++ b/coverage-parser/src/main/scala/com/codacy/parsers/implementation/CloverParser.scala
@@ -32,7 +32,7 @@ object CloverParser extends CoverageParser with XmlReportParser {
     val coverageFiles = (report \\ "file").foldLeft[Either[String, Seq[CoverageFileReport]]](Right(List())) {
       case (Right(accumulatedFileReports), fileTag) =>
         val fileReport = getCoverageFileReport(rootPath, fileTag)
-        fileReport.right.map(_ +: accumulatedFileReports)
+        fileReport.map(_ +: accumulatedFileReports)
 
       case (Left(errorMessage), _) => Left(errorMessage)
     }
@@ -76,7 +76,7 @@ object CloverParser extends CoverageParser with XmlReportParser {
           lineNumber <- getFirstNonEmptyValueAsInt(Seq(line), "num")
           countOfExecutions <- getFirstNonEmptyValueAsInt(Seq(line), "count")
         } yield (lineNumber, countOfExecutions)
-        lineCoverage.right.map(lines + _)
+        lineCoverage.map(lines + _)
 
       case (accumulated, _) => accumulated
     }

--- a/coverage-parser/src/test/scala/com/codacy/parsers/CloverParserTest.scala
+++ b/coverage-parser/src/test/scala/com/codacy/parsers/CloverParserTest.scala
@@ -3,9 +3,11 @@ package com.codacy.parsers
 import java.io.File
 
 import com.codacy.parsers.implementation.CloverParser
-import org.scalatest.{EitherValues, Matchers, WordSpec}
+import org.scalatest.EitherValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CloverParserTest extends WordSpec with Matchers with EitherValues {
+class CloverParserTest extends AnyWordSpec with Matchers with EitherValues {
 
   "parse" should {
 
@@ -46,7 +48,7 @@ class CloverParserTest extends WordSpec with Matchers with EitherValues {
         val parseResult = CloverParser.parse(new File("."), new File(cloverReportPath))
 
         // Assert
-        parseResult shouldBe 'right
+        parseResult shouldBe Symbol("right")
       }
 
       "the report does not have packages" in {
@@ -55,7 +57,7 @@ class CloverParserTest extends WordSpec with Matchers with EitherValues {
           .parse(new File("/home/codacy-php/"), new File(cloverWithoutPackagesFilePath))
 
         // Assert
-        parseResult shouldBe 'right
+        parseResult shouldBe Symbol("right")
       }
 
     }
@@ -70,7 +72,6 @@ class CloverParserTest extends WordSpec with Matchers with EitherValues {
         val parsedReportFilePaths =
           CloverParser
             .parse(new File("/Users/username/workspace/repository"), cloverWithPaths)
-            .right
             .value
             .fileReports
             .map(_.filename)
@@ -98,7 +99,7 @@ class CloverParserTest extends WordSpec with Matchers with EitherValues {
 
       // Act
       val fileReports =
-        CloverParser.parse(new File("/home/codacy-php/"), new File(cloverReportPath)).right.value.fileReports
+        CloverParser.parse(new File("/home/codacy-php/"), new File(cloverReportPath)).value.fileReports
 
       // Assert
       fileReports should have length expectedNumberOfFiles
@@ -118,7 +119,6 @@ class CloverParserTest extends WordSpec with Matchers with EitherValues {
       val parsedReportFilePaths =
         CloverParser
           .parse(new File("/home/codacy-php/"), new File(cloverReportPath))
-          .right
           .value
           .fileReports
           .map(_.filename)
@@ -135,7 +135,6 @@ class CloverParserTest extends WordSpec with Matchers with EitherValues {
       val fileLineCoverage =
         CloverParser
           .parse(new File("/home/codacy-php/"), new File(cloverReportPath))
-          .right
           .value
           .fileReports
           .find(_.filename == filePath)

--- a/coverage-parser/src/test/scala/com/codacy/parsers/CoberturaParserTest.scala
+++ b/coverage-parser/src/test/scala/com/codacy/parsers/CoberturaParserTest.scala
@@ -4,9 +4,11 @@ import java.io.File
 
 import com.codacy.api.{CoverageFileReport, CoverageReport}
 import com.codacy.parsers.implementation.CoberturaParser
-import org.scalatest.{BeforeAndAfterAll, EitherValues, Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, EitherValues}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CoberturaParserTest extends WordSpec with BeforeAndAfterAll with Matchers with EitherValues {
+class CoberturaParserTest extends AnyWordSpec with BeforeAndAfterAll with Matchers with EitherValues {
 
   "CoberturaParser" should {
 
@@ -35,7 +37,7 @@ class CoberturaParserTest extends WordSpec with BeforeAndAfterAll with Matchers 
         )
       )
 
-      reader.right.value should equal(testReport)
+      reader.value should equal(testReport)
     }
 
     "not crash on thousands separators" in {
@@ -52,7 +54,7 @@ class CoberturaParserTest extends WordSpec with BeforeAndAfterAll with Matchers 
         )
       )
 
-      reader.right.value should equal(testReport)
+      reader.value should equal(testReport)
     }
 
     "return a valid report with windows file path separator" in {
@@ -69,7 +71,7 @@ class CoberturaParserTest extends WordSpec with BeforeAndAfterAll with Matchers 
         )
       )
 
-      reader.right.value should equal(testReport)
+      reader.value should equal(testReport)
     }
 
   }

--- a/coverage-parser/src/test/scala/com/codacy/parsers/CoverageParserFactoryTest.scala
+++ b/coverage-parser/src/test/scala/com/codacy/parsers/CoverageParserFactoryTest.scala
@@ -3,9 +3,11 @@ package com.codacy.parsers
 import java.io.File
 
 import com.codacy.api.{CoverageFileReport, CoverageReport}
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class CoverageParserFactoryTest extends WordSpec with BeforeAndAfterAll with Matchers {
+class CoverageParserFactoryTest extends AnyWordSpec with BeforeAndAfterAll with Matchers {
 
   "CoverageParserFactory" should {
 

--- a/coverage-parser/src/test/scala/com/codacy/parsers/CoverageParserTest.scala
+++ b/coverage-parser/src/test/scala/com/codacy/parsers/CoverageParserTest.scala
@@ -3,9 +3,11 @@ package com.codacy.parsers
 import java.io.File
 import com.codacy.parsers.implementation._
 
-import org.scalatest.{BeforeAndAfterAll, EitherValues, Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, EitherValues}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class CoverageParserTest extends WordSpec with BeforeAndAfterAll with Matchers with EitherValues {
+class CoverageParserTest extends AnyWordSpec with BeforeAndAfterAll with Matchers with EitherValues {
   private val coberturaReportPath = "coverage-parser/src/test/resources/test_cobertura.xml"
   private val cloverReportPath = "coverage-parser/src/test/resources/test_clover.xml"
 
@@ -14,12 +16,12 @@ class CoverageParserTest extends WordSpec with BeforeAndAfterAll with Matchers w
       "the file cannot be parsed with a specific parser" in {
         val reader = CoverageParser.parse(new File("."), new File(coberturaReportPath), Some(CloverParser))
 
-        reader shouldBe 'left
+        reader shouldBe Symbol("left")
       }
       "the file cannot be parsed with another specific parser" in {
         val reader = CoverageParser.parse(new File("."), new File(coberturaReportPath), Some(LCOVParser))
 
-        reader shouldBe 'left
+        reader shouldBe Symbol("left")
       }
     }
     "return a valid result" when {
@@ -27,12 +29,12 @@ class CoverageParserTest extends WordSpec with BeforeAndAfterAll with Matchers w
         val reader =
           CoverageParser.parse(new File("."), new File(coberturaReportPath), Some(CoberturaParser))
 
-        reader shouldBe 'right
+        reader shouldBe Symbol("right")
       }
       "file and format are matching clover" in {
         val reader = CoverageParser.parse(new File("."), new File(cloverReportPath), Some(CloverParser))
 
-        reader shouldBe 'right
+        reader shouldBe Symbol("right")
       }
     }
   }

--- a/coverage-parser/src/test/scala/com/codacy/parsers/DotCoverParserTest.scala
+++ b/coverage-parser/src/test/scala/com/codacy/parsers/DotCoverParserTest.scala
@@ -4,9 +4,11 @@ import java.io.File
 
 import com.codacy.api.{CoverageFileReport, CoverageReport}
 import com.codacy.parsers.implementation.DotcoverParser
-import org.scalatest.{BeforeAndAfterAll, EitherValues, Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, EitherValues}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class DotCoverParserTest extends WordSpec with BeforeAndAfterAll with Matchers with EitherValues {
+class DotCoverParserTest extends AnyWordSpec with BeforeAndAfterAll with Matchers with EitherValues {
   private val nonExistentFile = "coverage-parser/src/test/resources/non-existent.xml"
   private val dotCoverReport = "coverage-parser/src/test/resources/test_dotcover.xml"
   private val differentFormatReport = "coverage-parser/src/test/resources/test_cobertura.xml"
@@ -15,25 +17,25 @@ class DotCoverParserTest extends WordSpec with BeforeAndAfterAll with Matchers w
       "report file does not exist" in {
         val reader = DotcoverParser.parse(new File("."), new File(nonExistentFile))
 
-        reader shouldBe 'left
+        reader shouldBe Symbol("left")
       }
 
       "report file has a different format" in {
         val reader = DotcoverParser.parse(new File("."), new File(differentFormatReport))
 
-        reader shouldBe 'left
+        reader shouldBe Symbol("left")
       }
     }
 
     "return a valid report" in {
       val reader = DotcoverParser.parse(new File("."), new File(dotCoverReport))
 
-      reader shouldBe 'right
+      reader shouldBe Symbol("right")
     }
 
     "return the expected files" in {
       val reader = DotcoverParser.parse(new File("."), new File(dotCoverReport))
-      reader.right.value.fileReports.map(_.filename).sorted shouldBe Seq(
+      reader.value.fileReports.map(_.filename).sorted shouldBe Seq(
         "src/Coverage/FooBar.cs",
         "src/Tests/FooBarTests.cs",
         "src/Coverage/Program.cs",
@@ -45,7 +47,7 @@ class DotCoverParserTest extends WordSpec with BeforeAndAfterAll with Matchers w
     "return the expected coverage report" in {
       val reader = DotcoverParser.parse(new File("."), new File(dotCoverReport))
 
-      reader.right.value shouldBe CoverageReport(
+      reader.value shouldBe CoverageReport(
         List(
           CoverageFileReport(
             "src/Coverage/FooBar.cs",

--- a/coverage-parser/src/test/scala/com/codacy/parsers/GoParserTest.scala
+++ b/coverage-parser/src/test/scala/com/codacy/parsers/GoParserTest.scala
@@ -5,9 +5,11 @@ import java.io.File
 import com.codacy.api._
 
 import com.codacy.parsers.implementation.GoParser
-import org.scalatest.{EitherValues, Matchers, WordSpec}
+import org.scalatest.{EitherValues}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class GoParserTest extends WordSpec with Matchers with EitherValues {
+class GoParserTest extends AnyWordSpec with Matchers with EitherValues {
 
   "parse" should {
 
@@ -37,7 +39,7 @@ class GoParserTest extends WordSpec with Matchers with EitherValues {
         )
       )
 
-      reader.right.value should equal(testReport)
+      reader.value should equal(testReport)
     }
 
     "return consistent values" in {
@@ -46,7 +48,7 @@ class GoParserTest extends WordSpec with Matchers with EitherValues {
       val reader1 =
         GoParser.parse(new File("."), new File("coverage-parser/src/test/resources/go/changed_package_name.out"))
 
-      reader.right.value.fileReports(0).coverage should equal(reader1.right.value.fileReports(0).coverage)
+      reader.value.fileReports(0).coverage should equal(reader1.value.fileReports(0).coverage)
     }
   }
 }

--- a/coverage-parser/src/test/scala/com/codacy/parsers/JacocoParserTest.scala
+++ b/coverage-parser/src/test/scala/com/codacy/parsers/JacocoParserTest.scala
@@ -4,9 +4,11 @@ import java.io.File
 
 import com.codacy.api._
 import com.codacy.parsers.implementation.JacocoParser
-import org.scalatest.{BeforeAndAfterAll, EitherValues, Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, EitherValues}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class JacocoParserTest extends WordSpec with BeforeAndAfterAll with Matchers with EitherValues {
+class JacocoParserTest extends AnyWordSpec with BeforeAndAfterAll with Matchers with EitherValues {
 
   "JacocoParser" should {
 
@@ -37,7 +39,7 @@ class JacocoParserTest extends WordSpec with BeforeAndAfterAll with Matchers wit
         )
       )
 
-      reader.right.value should equal(testReport)
+      reader.value should equal(testReport)
     }
   }
 

--- a/coverage-parser/src/test/scala/com/codacy/parsers/LCOVParserTest.scala
+++ b/coverage-parser/src/test/scala/com/codacy/parsers/LCOVParserTest.scala
@@ -4,9 +4,11 @@ import java.io.File
 
 import com.codacy.api._
 import com.codacy.parsers.implementation.LCOVParser
-import org.scalatest.{BeforeAndAfterAll, EitherValues, Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, EitherValues}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class LCOVParserTest extends WordSpec with BeforeAndAfterAll with Matchers with EitherValues {
+class LCOVParserTest extends AnyWordSpec with BeforeAndAfterAll with Matchers with EitherValues {
 
   "LCOVParser" should {
 
@@ -43,7 +45,7 @@ class LCOVParserTest extends WordSpec with BeforeAndAfterAll with Matchers with 
         )
       )
 
-      reader.right.value should equal(testReport)
+      reader.value should equal(testReport)
     }
 
   }

--- a/coverage-parser/src/test/scala/com/codacy/parsers/OpenCoverParserTest.scala
+++ b/coverage-parser/src/test/scala/com/codacy/parsers/OpenCoverParserTest.scala
@@ -4,9 +4,11 @@ import java.io.File
 
 import com.codacy.api.{CoverageFileReport, CoverageReport}
 import com.codacy.parsers.implementation.OpenCoverParser
-import org.scalatest.{BeforeAndAfterAll, EitherValues, Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, EitherValues}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class OpenCoverParserTest extends WordSpec with BeforeAndAfterAll with Matchers with EitherValues {
+class OpenCoverParserTest extends AnyWordSpec with BeforeAndAfterAll with Matchers with EitherValues {
   private val openCoverReportPath = "coverage-parser/src/test/resources/test_opencover.xml"
   private val nonExistentReportPath = "coverage-parser/src/test/resources/non_existent.xml"
   private val coberturaReportPath = "coverage-parser/src/test/resources/test_cobertura.xml"
@@ -14,30 +16,30 @@ class OpenCoverParserTest extends WordSpec with BeforeAndAfterAll with Matchers 
     "return an invalid report" when {
       "report file does not exist" in {
         val reader = OpenCoverParser.parse(new File("."), new File(nonExistentReportPath))
-        reader shouldBe 'left
+        reader shouldBe Symbol("left")
       }
 
       "report file has a different format" in {
         val reader = OpenCoverParser.parse(new File("."), new File(coberturaReportPath))
-        reader shouldBe 'left
+        reader shouldBe Symbol("left")
       }
     }
 
     "return a valid report" in {
       val reader = OpenCoverParser.parse(new File("."), new File(openCoverReportPath))
-      reader shouldBe 'right
+      reader shouldBe Symbol("right")
     }
 
     "return the expected files" in {
       val reader = OpenCoverParser.parse(new File("."), new File(openCoverReportPath))
 
-      reader.right.value.fileReports.map(_.filename).sorted shouldBe Seq("bar.cs", "foo.cs", "foobar.cs").sorted
+      reader.value.fileReports.map(_.filename).sorted shouldBe Seq("bar.cs", "foo.cs", "foobar.cs").sorted
     }
 
     "return the expected report" in {
       val reader = OpenCoverParser.parse(new File("."), new File(openCoverReportPath))
 
-      reader.right.value shouldBe CoverageReport(
+      reader.value shouldBe CoverageReport(
         List(
           CoverageFileReport("foo.cs", Map(10 -> 1)),
           CoverageFileReport("bar.cs", Map(10 -> 0)),

--- a/coverage-parser/src/test/scala/com/codacy/parsers/PhpUnitXmlParserTest.scala
+++ b/coverage-parser/src/test/scala/com/codacy/parsers/PhpUnitXmlParserTest.scala
@@ -3,9 +3,11 @@ package com.codacy.parsers
 import java.io.File
 
 import com.codacy.parsers.implementation.PhpUnitXmlParser
-import org.scalatest.{BeforeAndAfterAll, EitherValues, Matchers, WordSpec}
+import org.scalatest.{BeforeAndAfterAll, EitherValues}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class PhpUnitXmlParserTest extends WordSpec with BeforeAndAfterAll with Matchers with EitherValues {
+class PhpUnitXmlParserTest extends AnyWordSpec with BeforeAndAfterAll with Matchers with EitherValues {
   private val rootPath = "/home/codacy-php/"
   private val validReport = "coverage-parser/src/test/resources/phpunitxml/index.xml"
   private val incorrectReport = "coverage-parser/src/test/resources/phpunitxml/incorrect_index.xml"
@@ -18,14 +20,14 @@ class PhpUnitXmlParserTest extends WordSpec with BeforeAndAfterAll with Matchers
       "report file does not exist" in {
         val reader = PhpUnitXmlParser.parse(new File("."), new File(nonExistentReport))
 
-        reader shouldBe 'left
+        reader shouldBe Symbol("left")
       }
 
       "report file has a different format" in {
         // use some coverage file that does not follow the PHPUnit xml format
         val reader = PhpUnitXmlParser.parse(new File("."), new File(coberturaReport))
 
-        reader shouldBe 'left
+        reader shouldBe Symbol("left")
       }
 
       "report refers to non-existent file coverage report" in {
@@ -41,13 +43,12 @@ class PhpUnitXmlParserTest extends WordSpec with BeforeAndAfterAll with Matchers
       val reader = PhpUnitXmlParser
         .parse(new File(rootPath), new File(validReport))
 
-      reader shouldBe 'right
+      reader shouldBe Symbol("right")
     }
 
     "return a report with the expected number of files" in {
       val report = PhpUnitXmlParser
         .parse(new File(rootPath), new File(validReport))
-        .right
         .value
 
       report.fileReports.length shouldBe 10
@@ -56,7 +57,6 @@ class PhpUnitXmlParserTest extends WordSpec with BeforeAndAfterAll with Matchers
     "return a report with the expected file names" in {
       val report = PhpUnitXmlParser
         .parse(new File(rootPath), new File(validReport))
-        .right
         .value
 
       report.fileReports.map(_.filename).sorted shouldBe Seq(
@@ -76,7 +76,6 @@ class PhpUnitXmlParserTest extends WordSpec with BeforeAndAfterAll with Matchers
     "return a report with the expected line coverage" in {
       val report = PhpUnitXmlParser
         .parse(new File(rootPath), new File(validReport))
-        .right
         .value
 
       report.fileReports.find(_.filename.endsWith(configPhpFile)) match {

--- a/src/main/scala/com/codacy/configuration/parser/ConfigurationParser.scala
+++ b/src/main/scala/com/codacy/configuration/parser/ConfigurationParser.scala
@@ -67,18 +67,18 @@ case class Report(
     @Recurse
     baseConfig: BaseCommandConfig,
     @Name("l") @ValueDescription("language associated with your coverage report")
-    language: Option[String],
+    language: Option[String] = None,
     @Hidden @Name("f")
     forceLanguage: Int @@ Counter = Tag.of(0),
     @Name("r") @ValueDescription("your project coverage file name (supports globs)")
-    coverageReports: Option[List[File]],
+    coverageReports: Option[List[File]] = None,
     @ValueDescription("if the report is partial")
     partial: Int @@ Counter = Tag.of(0),
     @ValueDescription("the project path prefix")
-    prefix: Option[String],
+    prefix: Option[String] = None,
     @ValueDescription("your coverage parser")
     @HelpMessage(s"Available parsers are: ${ConfigArgumentParsers.parsersMap.keys.mkString(",")}")
-    forceCoverageParser: Option[CoverageParser]
+    forceCoverageParser: Option[CoverageParser] = None
 ) extends CommandConfiguration {
   val partialValue: Boolean = partial.## > 0
   val forceLanguageValue: Boolean = forceLanguage.## > 0
@@ -86,19 +86,19 @@ case class Report(
 
 case class BaseCommandConfig(
     @Name("t") @ValueDescription("your project API token")
-    projectToken: Option[String],
+    projectToken: Option[String] = None,
     @Name("a") @ValueDescription("your account api token")
-    apiToken: Option[String],
+    apiToken: Option[String] = None,
     @ValueDescription("organization provider")
-    organizationProvider: Option[OrganizationProvider.Value],
+    organizationProvider: Option[OrganizationProvider.Value] = None,
     @Name("u") @ValueDescription("your username")
-    username: Option[String],
+    username: Option[String] = None,
     @Name("p") @ValueDescription("project name")
-    projectName: Option[String],
+    projectName: Option[String] = None,
     @ValueDescription("the base URL for the Codacy API")
-    codacyApiBaseUrl: Option[String],
+    codacyApiBaseUrl: Option[String] = None,
     @ValueDescription("your commit SHA-1 hash")
-    commitUUID: Option[String],
+    commitUUID: Option[String] = None,
     @ValueDescription(
       "Sets a specified read timeout value, in milliseconds, to be used when interacting with Codacy API. By default, the value is 10 seconds"
     )

--- a/src/main/scala/com/codacy/rules/ConfigurationRules.scala
+++ b/src/main/scala/com/codacy/rules/ConfigurationRules.scala
@@ -146,7 +146,8 @@ class ConfigurationRules(cmdConfig: CommandConfiguration, envVars: Map[String, S
 
       val help = if (!config.codacyApiBaseUrl.startsWith("http")) {
         "Maybe you forgot the http:// or https:// ?"
-      }
+      } else ""
+
       Left(s"""|$error
                |$help""".stripMargin)
 

--- a/src/main/scala/com/codacy/rules/ReportRules.scala
+++ b/src/main/scala/com/codacy/rules/ReportRules.scala
@@ -15,7 +15,7 @@ import wvlet.log.LogSupport
 
 import java.io.File
 import java.nio.file.{FileSystems, Files}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class ReportRules(coverageServices: => CoverageServices, gitFileFetcher: GitFileFetcher) extends LogSupport {
 

--- a/src/test/scala/com/codacy/model/configuration/CommitUUIDSpec.scala
+++ b/src/test/scala/com/codacy/model/configuration/CommitUUIDSpec.scala
@@ -1,14 +1,16 @@
 package com.codacy.model.configuration
 
-import org.scalatest.{EitherValues, Matchers, WordSpec}
+import org.scalatest.EitherValues
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class CommitUUIDSpec extends WordSpec with Matchers with EitherValues {
+class CommitUUIDSpec extends AnyWordSpec with Matchers with EitherValues {
   "isValid" should {
     "approve commit uuids with 40 hexadecimal chars" in {
-      CommitUUID.fromString("ce280928adbdc852b8eefb0c57cf400f5f95db01") shouldBe 'right
-      CommitUUID.fromString("ce280928adbdc852b8eefb0c57cf400f5f95db0") shouldBe 'left
-      CommitUUID.fromString("ce280928adbdc852b8eefb0c57cf400f5f95db012") shouldBe 'left
-      CommitUUID.fromString("40 random characters that are not hexa!!") shouldBe 'left
+      CommitUUID.fromString("ce280928adbdc852b8eefb0c57cf400f5f95db01") shouldBe Symbol("right")
+      CommitUUID.fromString("ce280928adbdc852b8eefb0c57cf400f5f95db0") shouldBe Symbol("left")
+      CommitUUID.fromString("ce280928adbdc852b8eefb0c57cf400f5f95db012") shouldBe Symbol("left")
+      CommitUUID.fromString("40 random characters that are not hexa!!") shouldBe Symbol("left")
     }
   }
 }

--- a/src/test/scala/com/codacy/rules/ConfigurationRulesSpec.scala
+++ b/src/test/scala/com/codacy/rules/ConfigurationRulesSpec.scala
@@ -7,10 +7,12 @@ import com.codacy.model.configuration.ReportConfig
 import com.codacy.plugins.api.languages.Languages
 import org.scalatest.Inside._
 import org.scalatest._
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
 import java.io.File
 
-class ConfigurationRulesSpec extends WordSpec with Matchers with OptionValues with EitherValues {
+class ConfigurationRulesSpec extends AnyWordSpec with Matchers with OptionValues with EitherValues {
 
   val projToken = "1234adasdsdw333"
   val coverageFiles = List(new File("coverage.xml"))
@@ -22,7 +24,7 @@ class ConfigurationRulesSpec extends WordSpec with Matchers with OptionValues wi
     Report(baseConf, Some("Scala"), coverageReports = Some(coverageFiles), prefix = None, forceCoverageParser = None)
 
   val configRules = new ConfigurationRules(conf, Map.empty)
-  val validatedConfig = configRules.validatedConfig.right.value
+  val validatedConfig = configRules.validatedConfig.value
 
   val components = new Components(validatedConfig)
 
@@ -46,15 +48,15 @@ class ConfigurationRulesSpec extends WordSpec with Matchers with OptionValues wi
 
     "validate report files" in {
       val filesNoneOption = configRules.validateReportFiles(None)
-      filesNoneOption should be('right)
-      filesNoneOption.right.value should be(List.empty[File])
+      filesNoneOption should be(Symbol("right"))
+      filesNoneOption.value should be(List.empty[File])
 
       val filesSomeInvalid = configRules.validateReportFiles(Some(List.empty[File]))
-      filesSomeInvalid should be('left)
+      filesSomeInvalid should be(Symbol("left"))
 
       val filesSomeValid = configRules.validateReportFiles(Some(coverageFiles))
-      filesSomeValid should be('right)
-      filesSomeValid.right.value should be(coverageFiles)
+      filesSomeValid should be(Symbol("right"))
+      filesSomeValid.value should be(coverageFiles)
     }
 
     "get an api base url" in {
@@ -72,7 +74,7 @@ class ConfigurationRulesSpec extends WordSpec with Matchers with OptionValues wi
     "fail" when {
       def assertFailure(baseCommandConfig: BaseCommandConfig) = {
         val result = configRules.validateBaseConfig(baseCommandConfig)
-        result should be('left)
+        result should be(Symbol("left"))
         result
       }
 
@@ -181,7 +183,7 @@ class ConfigurationRulesSpec extends WordSpec with Matchers with OptionValues wi
             Some("ad7ce1b9973d31a2794565f892b6ae4cab575d7c")
           )
         val result = configRules.validateBaseConfig(baseConfig)
-        result should be('right)
+        result should be(Symbol("right"))
       }
 
       "api token and required fields are used" in {
@@ -196,7 +198,7 @@ class ConfigurationRulesSpec extends WordSpec with Matchers with OptionValues wi
             Some("ad7ce1b9973d31a2794565f892b6ae4cab575d7c")
           )
         val result = configRules.validateBaseConfig(baseConfig)
-        result should be('right)
+        result should be(Symbol("right"))
       }
 
       // it should use the project token only
@@ -212,7 +214,7 @@ class ConfigurationRulesSpec extends WordSpec with Matchers with OptionValues wi
             Some("ad7ce1b9973d31a2794565f892b6ae4cab575d7c")
           )
         val result = configRules.validateBaseConfig(baseConfig)
-        result should be('right)
+        result should be(Symbol("right"))
       }
     }
   }

--- a/src/test/scala/com/codacy/rules/commituuid/CommitUUIDProviderSpec.scala
+++ b/src/test/scala/com/codacy/rules/commituuid/CommitUUIDProviderSpec.scala
@@ -1,16 +1,18 @@
 package com.codacy.rules.commituuid
 
 import org.scalatest._
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class CommitUUIDProviderSpec extends WordSpec with Matchers with EitherValues {
+class CommitUUIDProviderSpec extends AnyWordSpec with Matchers with EitherValues {
   "getFromEnvironment" should {
     "provide a valid commit uuid" in {
       val envVars =
         Map("JENKINS_URL" -> "https://jenkins.example.com/", "GIT_COMMIT" -> "ad7ce1b9973d31a2794565f892b6ae4cab575d7c")
       val commitUuid = CommitUUIDProvider.getFromEnvironment(envVars)
 
-      commitUuid should be('right)
-      commitUuid.right.value.value should be("ad7ce1b9973d31a2794565f892b6ae4cab575d7c")
+      commitUuid should be(Symbol("right"))
+      commitUuid.value.value should be("ad7ce1b9973d31a2794565f892b6ae4cab575d7c")
     }
 
     "provide the first valid commit uuid, in provider order" in {
@@ -23,13 +25,13 @@ class CommitUUIDProviderSpec extends WordSpec with Matchers with EitherValues {
         )
       val commitUuid = CommitUUIDProvider.getFromEnvironment(envVars)
 
-      commitUuid should be('right)
-      commitUuid.right.value.value should be("1b097ecbbdd0204f908087d6fe1b94dc3453eaf9")
+      commitUuid should be(Symbol("right"))
+      commitUuid.value.value should be("1b097ecbbdd0204f908087d6fe1b94dc3453eaf9")
     }
 
     "not provide a commit uuid if the environment is empty" in {
       val commitUuid = CommitUUIDProvider.getFromEnvironment(Map.empty)
-      commitUuid should be('left)
+      commitUuid should be(Symbol("left"))
     }
 
     "not provide a commit uuid if the environment has no valid commits" in {
@@ -37,7 +39,7 @@ class CommitUUIDProviderSpec extends WordSpec with Matchers with EitherValues {
         Map("JENKINS_URL" -> "https://jenkins.example.com/", "GIT_COMMIT" -> "Commit UUID")
       val commitUuid = CommitUUIDProvider.getFromEnvironment(envVars)
 
-      commitUuid should be('left)
+      commitUuid should be(Symbol("left"))
     }
   }
 }

--- a/src/test/scala/com/codacy/rules/commituuid/providers/GitHubActionProviderSpec.scala
+++ b/src/test/scala/com/codacy/rules/commituuid/providers/GitHubActionProviderSpec.scala
@@ -1,8 +1,10 @@
 package com.codacy.rules.commituuid.providers
 
-import org.scalatest.{EitherValues, Matchers, WordSpec}
+import org.scalatest.{EitherValues}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class GitHubActionProviderSpec extends WordSpec with Matchers with EitherValues {
+class GitHubActionProviderSpec extends AnyWordSpec with Matchers with EitherValues {
   val validPullRequestCommitUuid = "480b8293f4340216b8f630053a230e2867cd5c28"
   val invalidPullRequestCommitUuid = "65e4436280a41c721617cba15f33555d3122907e"
 
@@ -13,12 +15,12 @@ class GitHubActionProviderSpec extends WordSpec with Matchers with EitherValues 
       "no environment variables are defined" in {
         val provider = GitHubActionProvider
         val commitUuidEither = provider.getValidCommitUUID(Map.empty)
-        commitUuidEither should be('left)
+        commitUuidEither should be(Symbol("left"))
       }
       "not pull request and GITHUB_SHA is empty" in {
         val provider = GitHubActionProvider
         val commitUuidEither = provider.getValidCommitUUID(Map("GITHUB_EVENT_NAME" -> "push"))
-        commitUuidEither should be('left)
+        commitUuidEither should be(Symbol("left"))
       }
       "github action does not have correct commit sha" in {
         val provider = GitHubActionProvider
@@ -28,7 +30,7 @@ class GitHubActionProviderSpec extends WordSpec with Matchers with EitherValues 
           "GITHUB_EVENT_PATH" -> "src/test/resources/invalid-github-action-pull-request-event.json"
         )
         val commitUuidEither = provider.getValidCommitUUID(envVars)
-        commitUuidEither should be('left)
+        commitUuidEither should be(Symbol("left"))
       }
     }
     "succeed" when {
@@ -36,8 +38,8 @@ class GitHubActionProviderSpec extends WordSpec with Matchers with EitherValues 
         val provider = GitHubActionProvider
         val envVars = Map("GITHUB_EVENT_NAME" -> "push", "GITHUB_SHA" -> validPullRequestCommitUuid)
         val commitUuidEither = provider.getValidCommitUUID(envVars)
-        commitUuidEither should be('right)
-        commitUuidEither.right.value.value should be(validPullRequestCommitUuid)
+        commitUuidEither should be(Symbol("right"))
+        commitUuidEither.value.value should be(validPullRequestCommitUuid)
       }
       "event is pull_request and json file includes needed information" in {
         val provider = GitHubActionProvider
@@ -47,8 +49,8 @@ class GitHubActionProviderSpec extends WordSpec with Matchers with EitherValues 
           "GITHUB_EVENT_PATH" -> "src/test/resources/github-action-pull-request-event.json"
         )
         val commitUuidEither = provider.getValidCommitUUID(envVars)
-        commitUuidEither should be('right)
-        commitUuidEither.right.value.value should be(validPullRequestCommitUuid)
+        commitUuidEither should be(Symbol("right"))
+        commitUuidEither.value.value should be(validPullRequestCommitUuid)
       }
       "event is workflow_run and json file includes needed information" in {
         val provider = GitHubActionProvider
@@ -58,8 +60,8 @@ class GitHubActionProviderSpec extends WordSpec with Matchers with EitherValues 
           "GITHUB_EVENT_PATH" -> "src/test/resources/github-action-workflow-run-event.json"
         )
         val commitUuidEither = provider.getValidCommitUUID(envVars)
-        commitUuidEither should be('right)
-        commitUuidEither.right.value.value should be(validWorkflowRunCommitUuid)
+        commitUuidEither should be(Symbol("right"))
+        commitUuidEither.value.value should be(validWorkflowRunCommitUuid)
       }
     }
   }

--- a/src/test/scala/com/codacy/transformation/FileNameMatcherSpec.scala
+++ b/src/test/scala/com/codacy/transformation/FileNameMatcherSpec.scala
@@ -1,8 +1,10 @@
 package com.codacy.transformation
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
 
-class FileNameMatcherSpec extends WordSpec with Matchers {
+class FileNameMatcherSpec extends AnyWordSpec with Matchers with OptionValues {
 
   "matchAndReturnName" should {
     "return name from closest match" in {
@@ -15,7 +17,7 @@ class FileNameMatcherSpec extends WordSpec with Matchers {
 
       // ASSERT
       newFilename.isDefined shouldBe true
-      newFilename.leftSideValue shouldBe Some("src/folder/package/file.txt")
+      newFilename.value shouldBe "src/folder/package/file.txt"
     }
 
     "return empty when name doesn't match any filenames" in {

--- a/src/test/scala/com/codacy/transformation/GitFileNameUpdaterAndFilterSpec.scala
+++ b/src/test/scala/com/codacy/transformation/GitFileNameUpdaterAndFilterSpec.scala
@@ -2,9 +2,10 @@ package com.codacy.transformation
 
 import com.codacy.api.{CoverageFileReport, CoverageReport}
 import com.codacy.transformation.FileNameMatcher.getFilenameFromPath
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class GitFileNameUpdaterAndFilterSpec extends WordSpec with Matchers {
+class GitFileNameUpdaterAndFilterSpec extends AnyWordSpec with Matchers {
 
   private val acceptableFilenames =
     Seq("src/folder/file1.txt", "src/another-folder/file1.txt", "src/folder/file2.txt", "src/folder/file3.txt")

--- a/src/test/scala/com/codacy/transformation/PathPrefixerSpec.scala
+++ b/src/test/scala/com/codacy/transformation/PathPrefixerSpec.scala
@@ -2,8 +2,10 @@ package com.codacy.transformation
 
 import com.codacy.api.{CoverageFileReport, CoverageReport}
 import org.scalatest._
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class PathPrefixerSpec extends WordSpec with Matchers {
+class PathPrefixerSpec extends AnyWordSpec with Matchers {
 
   val report = CoverageReport(
     Seq(CoverageFileReport("Filename.scala", Map.empty), CoverageFileReport("OtherFile.scala", Map.empty))


### PR DESCRIPTION
Scala 3 case-app doesn't depend on shapeless anymore, which should reduce the binary size
This also updates dependencies to their Scala 3 compatible counterpart
- `case-app` is updated to `2.1.0-M28`
- `airframe-log` is updated to `24.6.0`
- `mockito` is replaced with `scalamock` which supports scala 3
- `scalatest` is updated to `3.2.18`
- `play-json` is updated to `2.10.5`
- `codacy-plugins-api` is updated to `8.1.4`
- `scala-xml` is updated to `2.3.0`