### PR TITLE
Use the correct env var for Git SHA

### DIFF
--- a/src/main/scala/com/codacy/rules/commituuid/providers/SemaphoreCIProvider.scala
+++ b/src/main/scala/com/codacy/rules/commituuid/providers/SemaphoreCIProvider.scala
@@ -12,5 +12,5 @@ object SemaphoreCIProvider extends CommitUUIDProvider {
   }
 
   override def getValidCommitUUID(environment: Map[String, String]): Either[String, CommitUUID] =
-    parseEnvironmentVariable(environment.get("REVISION"))
+    parseEnvironmentVariable(environment.get("SEMAPHORE_GIT_SHA"))
 }


### PR DESCRIPTION
Seeing the following error on Semaphore CI for the Codacy reporter

```
2025-02-24 18:06:15.963+0100  info [CommitUUIDProvider] Can't find or validate commit SHA-1 hash from any supported CI/CD provider.  - (CommitUUIDProvider.scala:97) 00:05
2025-02-24 18:06:15.963+0100  info [CommitUUIDProvider] Trying to get commit SHA-1 hash from local Git directory  - (CommitUUIDProvider.scala:98) 00:05
2025-02-24 18:06:15.964+0100  info [CommitUUIDProvider] 00:05
Commit SHA-1 hash not provided, using latest commit of local Git directory:
```

Hopefully updating to the correct env var will fix this.
https://docs.semaphoreci.com/reference/env-vars#semaphore-variables